### PR TITLE
Remove bevy asset meta data check

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{asset::AssetMetaCheck, prelude::*};
 use bevy_vello::{
     debug::DebugVisualizations, ColorPaletteSwap, Origin, VelloPlugin, VelloText, VelloTextBundle,
     VelloVector, VelloVectorBundle,
@@ -11,6 +11,7 @@ const SUCKERS: Color = Color::rgba(235. / 255., 189. / 255., 1.0, 1.0);
 
 fn main() {
     App::new()
+        .insert_resource(AssetMetaCheck::Never)
         .add_plugins(DefaultPlugins.set(AssetPlugin { ..default() }))
         .add_plugins(VelloPlugin)
         .add_systems(Startup, setup_vector_graphics)


### PR DESCRIPTION
Due to this [error/related issue](https://github.com/bevyengine/bevy/issues/10157#issuecomment-1799066736) on wasm builds with the new bevy assetv2 pipeline, the recommended solution was to disable asset meta data checks.