### PR TITLE
Redid render ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,7 @@ A bevy plugin which provides rendering support for [lottie](https://lottiefiles.
 
 ## Features
 
-- Spawn vector graphics on separate layers
-  |Layer|Render order|
-  |---|---|
-  |Background|Always behind all other layers|
-  |Ground|2.5D-style render ordering via Y-coordinate|
-  |Foreground|Always on top of Ground/Background|
-  |UI|On top of Foreground layer; shows Bevy UI Nodes bundled with a `VelloVector` |
+- Spawn vector graphics rendering either in screen-space or world-space coordinates.
 - Support for fonts
   - NOTE: to avoid conflict with bevy's built-in font loader, rename fonts used by `bevy-vello` to something else (example: `*.vtff`). This can probably be an improvement in the future.
 - Debug draw gizmos for the objects local origin (red X) and canvas size (white bounding box)

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -23,7 +23,6 @@ fn setup_vector_graphics(mut commands: Commands, asset_server: ResMut<AssetServe
     commands.spawn(Camera2dBundle::default());
     commands
         .spawn(VelloVectorBundle {
-            layer: bevy_vello::Layer::Background,
             origin: bevy_vello::Origin::Center,
             // Can only load *.json (Lottie animations) and *.svg (static vector graphics)
             vector: asset_server.load("../assets/squid.json"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,15 +63,12 @@ impl Plugin for VelloPlugin {
     }
 }
 
-#[derive(PartialEq, Component, Default, Copy, Clone, Debug, Reflect)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Component, Default, Copy, Clone, Debug, Reflect)]
 #[reflect(Component)]
-pub enum Layer {
-    Background,
-    Shadow,
+pub enum RenderMode {
     #[default]
-    Ground,
-    Foreground,
-    UI,
+    WorldSpace = 0,
+    ScreenSpace = 1,
 }
 
 #[derive(PartialEq, Component, Default, Copy, Clone, Debug, Reflect)]
@@ -129,8 +126,8 @@ impl ColorPaletteSwap {
 #[derive(Bundle)]
 pub struct VelloVectorBundle {
     pub vector: Handle<VelloVector>,
-    /// Configures the draw order within the vello canvas
-    pub layer: Layer,
+    /// The coordinate space in which this vector should be rendered.
+    pub render_mode: RenderMode,
     /// This object's transform local origin. Enable debug visualizations to visualize (red X)
     pub origin: Origin,
     pub transform: Transform,
@@ -149,7 +146,7 @@ impl Default for VelloVectorBundle {
     fn default() -> Self {
         Self {
             vector: Default::default(),
-            layer: Default::default(),
+            render_mode: RenderMode::WorldSpace,
             origin: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
@@ -172,7 +169,7 @@ pub struct VelloText {
 pub struct VelloTextBundle {
     pub font: Handle<VelloFont>,
     pub text: VelloText,
-    pub layer: Layer,
+    pub render_mode: RenderMode,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
@@ -188,7 +185,7 @@ impl Default for VelloTextBundle {
         Self {
             font: Default::default(),
             text: Default::default(),
-            layer: Layer::Foreground,
+            render_mode: RenderMode::WorldSpace,
             transform: Default::default(),
             global_transform: Default::default(),
             visibility: Visibility::Inherited,

--- a/src/renderer/extract.rs
+++ b/src/renderer/extract.rs
@@ -4,14 +4,14 @@ use bevy::{
     window::PrimaryWindow,
 };
 
-use crate::{font::VelloFont, ColorPaletteSwap, Layer, Origin, VelloText, VelloVector};
+use crate::{font::VelloFont, ColorPaletteSwap, Origin, RenderMode, VelloText, VelloVector};
 
 #[derive(Component, Clone)]
 pub struct ExtractedRenderVector {
     pub vector_handle: Handle<VelloVector>,
     pub render_data: VelloVector,
     pub transform: GlobalTransform,
-    pub layer: Layer,
+    pub render_mode: RenderMode,
     pub origin: Origin,
     pub color_pallette_swap: Option<ColorPaletteSwap>,
     pub ui_node: Option<Node>,
@@ -22,7 +22,7 @@ pub fn vector_instances(
     query_vectors: Extract<
         Query<(
             &Handle<VelloVector>,
-            &Layer,
+            &RenderMode,
             Option<&Origin>,
             &GlobalTransform,
             Option<&ColorPaletteSwap>,
@@ -35,7 +35,7 @@ pub fn vector_instances(
 ) {
     for (
         vello_vector_handle,
-        layer,
+        render_mode,
         origin,
         transform,
         color_pallette_swap,
@@ -50,7 +50,7 @@ pub fn vector_instances(
                     vector_handle: vello_vector_handle.clone(),
                     render_data: asset_data.to_owned(),
                     transform: *transform,
-                    layer: *layer,
+                    render_mode: *render_mode,
                     origin: origin.copied().unwrap_or_default(),
                     color_pallette_swap: color_pallette_swap.cloned(),
                     ui_node: ui_node.cloned(),
@@ -65,7 +65,7 @@ pub struct ExtractedRenderText {
     pub font: Handle<VelloFont>,
     pub text: VelloText,
     pub transform: GlobalTransform,
-    pub layer: Layer,
+    pub render_mode: RenderMode,
 }
 
 impl ExtractComponent for ExtractedRenderText {
@@ -73,20 +73,23 @@ impl ExtractComponent for ExtractedRenderText {
         &'static Handle<VelloFont>,
         &'static VelloText,
         &'static GlobalTransform,
-        &'static Layer,
+        &'static RenderMode,
     );
 
     type Filter = ();
     type Out = Self;
 
     fn extract_component(
-        (vello_font_handle, text, transform, layer): bevy::ecs::query::QueryItem<'_, Self::Query>,
+        (vello_font_handle, text, transform, render_mode): bevy::ecs::query::QueryItem<
+            '_,
+            Self::Query,
+        >,
     ) -> Option<Self> {
         Some(Self {
             font: vello_font_handle.clone(),
             text: text.clone(),
             transform: *transform,
-            layer: *layer,
+            render_mode: *render_mode,
         })
     }
 }

--- a/src/rendertarget.rs
+++ b/src/rendertarget.rs
@@ -16,7 +16,7 @@ use bevy::{
     window::{WindowResized, WindowResolution},
 };
 
-use crate::{renderer::SSRenderTarget, Layer, SSRT_SHADER_HANDLE};
+use crate::{renderer::SSRenderTarget, RenderMode, SSRT_SHADER_HANDLE};
 
 #[derive(Component)]
 struct MainCamera;
@@ -199,7 +199,7 @@ impl Material2d for VelloCanvasMaterial {
 /// Hide the RenderTarget canvas if there is nothing to render
 pub fn clear_when_empty(
     mut query_render_target: Query<&mut Visibility, With<SSRenderTarget>>,
-    render_items: Query<(&mut Layer, &ViewVisibility)>,
+    render_items: Query<(&mut RenderMode, &ViewVisibility)>,
 ) {
     if let Ok(mut visibility) = query_render_target.get_single_mut() {
         if render_items.is_empty() {


### PR DESCRIPTION
#### Changes
- Added a `RenderMode` struct to define `RenderMode::ScreenSpace` or `RenderMode::WorldSpace` . 
- Removed the `Layer` struct which previously defined the draw order.

Redid the render ordering to sort by the vector's **z** position since the transform is already being included for a 2d affine transformation so the **z** component doesn't go unused; this is assuming the z component of the transform isn't used to represent other things. Vectors in world-space are rendered first, then screen-space so that screen-space vectors have their own independent z-ordering.

Previously text was already rendered after other vectors so it would always appear on top, I changed this behavior to follow along with the ordering of all the other vectors, regardless if it's text or not.