### PR TITLE
WIP: Bevy 0.13 updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
+    branches:
+      - main
+
 
 jobs:
   release-web:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This changelog follows the patterns described here: <https://keepachangelog.com/
 Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
 
 
+## 0.6
+
+### changed
+
+- Bevy 0.13 support
+
 ## 0.5.1
 
 ### fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/vectorgameexperts/bevy-vello"
 
 [workspace.dependencies]
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
   "bevy_asset",
   "bevy_winit",
   "bevy_core_pipeline",
@@ -42,7 +42,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy = { workspace = true }
-vello = { git = "https://github.com/linebender/vello", rev = "28914d66f675efecf03c53261a0fb1b8ecce4fe9" }
+vello = { git = "https://github.com/linebender/vello", rev = "f164ffc01710a996ee6e3c0e0783635b3aaef209" }
 vello-svg = { git = "https://github.com/vectorgameexperts/vello-svg", version = "0.2" }
 vellottie = { git = "https://github.com/vectorgameexperts/vellottie", version = "0.2" }
 # FIXME: Remove later on, web-sys got angry in v0.3.38.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ bevy = { version = "0.13", default-features = false, features = [
   "tonemapping_luts",
   "bevy_gizmos",
 ] }
-# FIXME: Remove later on, web-sys got angry in v0.3.38.
-web-sys = ">=0.3, <0.3.68"
+web-sys = "0.3.67"
 
 [package]
 name = "bevy-vello"
@@ -42,11 +41,9 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy = { workspace = true }
-vello = { git = "https://github.com/linebender/vello", rev = "f164ffc01710a996ee6e3c0e0783635b3aaef209" }
-vello-svg = { git = "https://github.com/vectorgameexperts/vello-svg", version = "0.2" }
-vellottie = { git = "https://github.com/vectorgameexperts/vellottie", version = "0.2" }
-# FIXME: Remove later on, web-sys got angry in v0.3.38.
-web-sys = { workspace = true }
+vello = "0.1"
+vello-svg = { git = "https://github.com/vectorgameexperts/vello-svg", version = "0.3" }
+vellottie = { git = "https://github.com/vectorgameexperts/vellottie", version = "0.3" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bevy = { version = "0.13", default-features = false, features = [
   "tonemapping_luts",
   "bevy_gizmos",
 ] }
-web-sys = "0.3.67"
 
 [package]
 name = "bevy-vello"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A bevy plugin which provides rendering support for [lottie](https://lottiefiles.
 
 |bevy|bevy-vello|
 |---|---|
-|0.12|0.3-0.5, main|
+|0.12|0.6, main|
+|0.12|0.3-0.5|
 |0.11|0.2|
 |<= 0.10|0.1|
 

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -11,7 +11,5 @@ publish = false
 [dependencies]
 bevy-vello = { path = "../" }
 bevy = { workspace = true }
-bevy_pancam = { version = "0.10", features = ["bevy_egui"] }
-bevy_egui = "0.23"
-# FIXME: Remove later on, web-sys got angry in v0.3.38.
-web-sys = { workspace = true }
+bevy_pancam = { version = "0.11", features = ["bevy_egui"] }
+bevy_egui = "0.25"

--- a/examples/drag-n-drop/Cargo.toml
+++ b/examples/drag-n-drop/Cargo.toml
@@ -10,5 +10,3 @@ publish = false
 [dependencies]
 bevy-vello = { path = "../../" }
 bevy = { workspace = true }
-# FIXME: Remove later on, web-sys got angry in v0.3.38.
-web-sys = { workspace = true }

--- a/examples/text/Cargo.toml
+++ b/examples/text/Cargo.toml
@@ -10,6 +10,4 @@ publish = false
 [dependencies]
 bevy-vello = { path = "../../" }
 bevy = { workspace = true }
-bevy_pancam = { version = "0.10", features = ["bevy_egui"] }
-# FIXME: Remove later on, web-sys got angry in v0.3.38.
-web-sys = { workspace = true }
+bevy_pancam = { version = "0.11", features = ["bevy_egui"] }

--- a/examples/text/src/main.rs
+++ b/examples/text/src/main.rs
@@ -81,6 +81,6 @@ fn setup_screenspace_text(
             left: Val::Px(100.0),
             ..default()
         })
-        .with_text_alignment(TextAlignment::Left),
+        .with_text_justify(JustifyText::Left),
     );
 }

--- a/examples/z-ordering/Cargo.toml
+++ b/examples/z-ordering/Cargo.toml
@@ -10,6 +10,4 @@ publish = false
 [dependencies]
 bevy-vello = { path = "../../" }
 bevy = { workspace = true }
-bevy_pancam = { version = "0.10", features = ["bevy_egui"] }
-# FIXME: Remove later on, web-sys got angry in v0.3.38.
-web-sys = { workspace = true }
+bevy_pancam = { version = "0.11", features = ["bevy_egui"] }

--- a/shaders/vello_ss_rendertarget.wgsl
+++ b/shaders/vello_ss_rendertarget.wgsl
@@ -2,9 +2,9 @@
 
 @group(0) @binding(0)
 var<uniform> view: View;
-@group(1) @binding(0)
+@group(2) @binding(0)
 var texture: texture_2d<f32>;
-@group(1) @binding(1)
+@group(2) @binding(1)
 var texture_sampler: sampler;
 
 // returns the (0-1, 0-1) position within the given viewport for the current buffer coords .

--- a/src/assets/asset.rs
+++ b/src/assets/asset.rs
@@ -1,13 +1,13 @@
 use super::Metadata;
 use bevy::{prelude::*, reflect::TypePath};
 use std::sync::Arc;
-use vello::SceneFragment;
+use vello::Scene;
 
 #[derive(Clone)]
 pub enum VectorFile {
     Svg {
-        /// The original image encoding
-        original: Arc<SceneFragment>,
+        /// A static scene
+        scene: Arc<Scene>,
     },
     Lottie {
         /// The original image encoding

--- a/src/assets/parser.rs
+++ b/src/assets/parser.rs
@@ -2,7 +2,7 @@ use super::asset_loader::VectorLoaderError;
 use crate::{assets::asset::VectorFile, VelloAsset};
 use bevy::prelude::*;
 use std::sync::Arc;
-use vello::{SceneBuilder, SceneFragment};
+use vello::Scene;
 use vello_svg::usvg::{self, TreeParsing};
 
 /// Deserialize an SVG file from bytes.
@@ -14,16 +14,15 @@ pub fn load_svg_from_bytes(
     let usvg = usvg::Tree::from_str(svg_str, &usvg::Options::default())?;
 
     // Process the loaded SVG into Vello-compatible data
-    let mut scene_frag = SceneFragment::new();
-    let mut builder = SceneBuilder::for_fragment(&mut scene_frag);
-    vello_svg::render_tree(&mut builder, &usvg);
+    let mut scene = Scene::new();
+    vello_svg::render_tree(&mut scene, &usvg);
 
     let width = usvg.size.width();
     let height = usvg.size.height();
 
     let vello_vector = VelloAsset {
         data: VectorFile::Svg {
-            original: Arc::new(scene_frag),
+            scene: Arc::new(scene),
         },
         local_transform_center: {
             let mut transform = Transform::default();

--- a/src/player/systems.rs
+++ b/src/player/systems.rs
@@ -177,7 +177,7 @@ pub fn run_transitions(
     mut assets: ResMut<Assets<VelloAsset>>,
     windows: Query<&Window>,
     query_view: Query<(&Camera, &GlobalTransform), With<Camera2d>>,
-    buttons: Res<Input<MouseButton>>,
+    buttons: Res<ButtonInput<MouseButton>>,
     mut hovered: Local<bool>,
 ) {
     let Ok(window) = windows.get_single() else {

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -75,37 +75,37 @@ pub fn vector_instances(
     }
 }
 
-#[derive(Component, Clone)]
+#[derive(Component)]
 pub struct ExtractedRenderText {
-    pub font: Handle<VelloFont>,
+    pub font: VelloFont,
     pub text: VelloText,
     pub transform: GlobalTransform,
     pub render_mode: CoordinateSpace,
 }
 
-impl ExtractComponent for ExtractedRenderText {
-    type Query = (
-        &'static Handle<VelloFont>,
-        &'static VelloText,
-        &'static GlobalTransform,
-        &'static CoordinateSpace,
-    );
-
-    type Filter = ();
-    type Out = Self;
-
-    fn extract_component(
-        (vello_font_handle, text, transform, render_mode): bevy::ecs::query::QueryItem<
-            '_,
-            Self::Query,
-        >,
-    ) -> Option<Self> {
-        Some(Self {
-            font: vello_font_handle.clone(),
-            text: text.clone(),
-            transform: *transform,
-            render_mode: *render_mode,
-        })
+pub fn text_instances(
+    mut commands: Commands,
+    query_vectors: Extract<
+        Query<(
+            &Handle<VelloFont>,
+            &VelloText,
+            &GlobalTransform,
+            &CoordinateSpace,
+        )>,
+    >,
+    assets: Extract<Res<Assets<VelloFont>>>,
+) {
+    for (vello_font_handle, vello_text, transform, coordinate_space) in
+        query_vectors.iter()
+    {
+        if let Some(asset) = assets.get(vello_font_handle) {
+            commands.spawn(ExtractedRenderText {
+                font: *asset.to_owned(),
+                text: *vello_text,
+                transform: *transform,
+                render_mode: *coordinate_space,
+            });
+        }
     }
 }
 
@@ -113,14 +113,14 @@ impl ExtractComponent for ExtractedRenderText {
 pub struct SSRenderTarget(pub Handle<Image>);
 
 impl ExtractComponent for SSRenderTarget {
-    type Query = &'static SSRenderTarget;
+    type QueryData = &'static SSRenderTarget;
 
-    type Filter = ();
+    type QueryFilter = ();
 
     type Out = Self;
 
     fn extract_component(
-        ss_render_target: bevy::ecs::query::QueryItem<'_, Self::Query>,
+        ss_render_target: bevy::ecs::query::QueryItem<'_, Self::QueryData>,
     ) -> Option<Self> {
         Some(Self(ss_render_target.0.clone()))
     }

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -75,37 +75,38 @@ pub fn vector_instances(
     }
 }
 
-#[derive(Component)]
+#[derive(Component, Clone)]
 pub struct ExtractedRenderText {
-    pub font: VelloFont,
+    pub font: Handle<VelloFont>,
     pub text: VelloText,
     pub transform: GlobalTransform,
     pub render_mode: CoordinateSpace,
 }
 
-pub fn text_instances(
-    mut commands: Commands,
-    query_vectors: Extract<
-        Query<(
-            &Handle<VelloFont>,
-            &VelloText,
-            &GlobalTransform,
-            &CoordinateSpace,
-        )>,
-    >,
-    assets: Extract<Res<Assets<VelloFont>>>,
-) {
-    for (vello_font_handle, vello_text, transform, coordinate_space) in
-        query_vectors.iter()
-    {
-        if let Some(asset) = assets.get(vello_font_handle) {
-            commands.spawn(ExtractedRenderText {
-                font: *asset.to_owned(),
-                text: *vello_text,
-                transform: *transform,
-                render_mode: *coordinate_space,
-            });
-        }
+impl ExtractComponent for ExtractedRenderText {
+    type QueryData = (
+        &'static Handle<VelloFont>,
+        &'static VelloText,
+        &'static GlobalTransform,
+        &'static CoordinateSpace,
+    );
+
+    type QueryFilter = ();
+
+    type Out = Self;
+
+    fn extract_component(
+        (vello_font_handle, text, transform, render_mode): bevy::ecs::query::QueryItem<
+            '_,
+            Self::QueryData,
+        >,
+    ) -> Option<Self> {
+        Some(Self {
+            font: vello_font_handle.clone(),
+            text: text.clone(),
+            transform: *transform,
+            render_mode: *render_mode,
+        })
     }
 }
 
@@ -135,7 +136,7 @@ pub fn extract_pixel_scale(
 ) {
     let scale_factor = windows
         .get_single()
-        .map(|window| window.resolution.scale_factor() as f32)
+        .map(|window| window.resolution.scale_factor())
         .unwrap_or(1.0);
 
     pixel_scale.0 = scale_factor;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,6 +1,5 @@
 use bevy::{
     prelude::*,
-    reflect::TypeUuid,
     render::{
         mesh::MeshVertexBufferLayout,
         render_resource::{
@@ -28,8 +27,7 @@ pub const SSRT_SHADER_HANDLE: Handle<Shader> =
     Handle::weak_from_u128(2314894693238056781);
 
 /// A canvas material, with a shader that samples a texture with view-independent UV coordinates.
-#[derive(AsBindGroup, TypeUuid, TypePath, Asset, Clone)]
-#[uuid = "b62bb455-a72c-4b56-87bb-81e0554e234f"]
+#[derive(AsBindGroup, TypePath, Asset, Clone)]
 pub struct VelloCanvasMaterial {
     #[texture(0)]
     #[sampler(1)]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -75,13 +75,13 @@ impl FromWorld for BevyVelloRenderer {
                 device.wgpu_device(),
                 RendererOptions {
                     surface_format: None,
-                    timestamp_period: 0.0,
                     use_cpu: false,
                     antialiasing_support: vello::AaSupport {
                         area: true,
                         msaa8: false,
                         msaa16: false,
                     },
+                    num_init_threads: None,
                 },
             )
             .expect("no gpu device"),

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -1,15 +1,14 @@
 use super::{
-    extract::{self, ExtractedPixelScale, ExtractedRenderText, SSRenderTarget},
+    extract::{self, ExtractedPixelScale, SSRenderTarget},
     prepare, systems, BevyVelloRenderer, LottieRenderer,
 };
-use crate::{render::SSRT_SHADER_HANDLE, VelloCanvasMaterial, VelloFont};
+use crate::{render::SSRT_SHADER_HANDLE, VelloCanvasMaterial};
 use bevy::{
     asset::load_internal_asset,
     prelude::*,
     render::{
-        extract_component::ExtractComponentPlugin,
-        render_asset::RenderAssetPlugin, renderer::RenderDevice, Render,
-        RenderApp, RenderSet,
+        extract_component::ExtractComponentPlugin, renderer::RenderDevice,
+        Render, RenderApp, RenderSet,
     },
     sprite::Material2dPlugin,
 };
@@ -81,13 +80,13 @@ impl Plugin for VelloRenderPlugin {
                 device.wgpu_device(),
                 RendererOptions {
                     surface_format: None,
-                    timestamp_period: 0.0,
                     use_cpu: false,
                     antialiasing_support: AaSupport {
                         area: true,
                         msaa8: false,
                         msaa16: false,
                     },
+                    num_init_threads: None,
                 },
             )
             .unwrap(),

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -56,9 +56,7 @@ impl Plugin for VelloRenderPlugin {
 
         app.add_plugins((
             Material2dPlugin::<VelloCanvasMaterial>::default(),
-            ExtractComponentPlugin::<ExtractedRenderText>::default(),
             ExtractComponentPlugin::<SSRenderTarget>::default(),
-            RenderAssetPlugin::<VelloFont>::default(),
         ))
         .add_systems(Startup, systems::setup_ss_rendertarget)
         .add_systems(

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -2,13 +2,17 @@ use super::{
     extract::{self, ExtractedPixelScale, SSRenderTarget},
     prepare, systems, BevyVelloRenderer, LottieRenderer,
 };
-use crate::{render::SSRT_SHADER_HANDLE, VelloCanvasMaterial};
+use crate::{
+    render::{extract::ExtractedRenderText, SSRT_SHADER_HANDLE},
+    VelloCanvasMaterial, VelloFont,
+};
 use bevy::{
     asset::load_internal_asset,
     prelude::*,
     render::{
-        extract_component::ExtractComponentPlugin, renderer::RenderDevice,
-        Render, RenderApp, RenderSet,
+        extract_component::ExtractComponentPlugin,
+        render_asset::RenderAssetPlugin, renderer::RenderDevice, Render,
+        RenderApp, RenderSet,
     },
     sprite::Material2dPlugin,
 };
@@ -55,7 +59,9 @@ impl Plugin for VelloRenderPlugin {
 
         app.add_plugins((
             Material2dPlugin::<VelloCanvasMaterial>::default(),
+            ExtractComponentPlugin::<ExtractedRenderText>::default(),
             ExtractComponentPlugin::<SSRenderTarget>::default(),
+            RenderAssetPlugin::<VelloFont>::default(),
         ))
         .add_systems(Startup, systems::setup_ss_rendertarget)
         .add_systems(

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateSpace, VectorFile, VelloCanvasMaterial, VelloFont};
+use crate::{CoordinateSpace, VectorFile, VelloCanvasMaterial};
 use bevy::{
     prelude::*,
     render::{
@@ -14,7 +14,7 @@ use bevy::{
     sprite::{MaterialMesh2dBundle, Mesh2dHandle},
     window::{WindowResized, WindowResolution},
 };
-use vello::{RenderParams, Scene, SceneBuilder};
+use vello::{RenderParams, Scene};
 
 use super::{
     extract::{ExtractedRenderText, ExtractedRenderVector, SSRenderTarget},
@@ -77,8 +77,7 @@ pub fn render_scene(
         ss_render_target.get_single()
     {
         let gpu_image = gpu_images.get(render_target_image).unwrap();
-        let mut scene = Scene::default();
-        let mut builder = SceneBuilder::for_scene(&mut scene);
+        let mut scene = Scene::new();
 
         enum RenderItem<'a> {
             Vector(&'a ExtractedRenderVector),
@@ -127,10 +126,8 @@ pub fn render_scene(
                     playhead,
                     ..
                 }) => match &asset.data {
-                    VectorFile::Svg {
-                        original: fragment, ..
-                    } => {
-                        builder.append(fragment, Some(affine));
+                    VectorFile::Svg { scene: svg, .. } => {
+                        scene.append(svg, Some(affine));
                     }
                     VectorFile::Lottie { composition } => {
                         debug!("playhead: {playhead}");
@@ -145,14 +142,14 @@ pub fn render_scene(
                             *playhead,
                             affine,
                             *alpha,
-                            &mut builder,
+                            &mut scene,
                         );
                     }
                 },
                 RenderItem::Text(ExtractedRenderText {
                     font, text, ..
                 }) => {
-                    font.render(&mut builder, affine, text);
+                    font.render(&mut scene, affine, text);
                 }
             }
         }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateSpace, VectorFile, VelloCanvasMaterial};
+use crate::{CoordinateSpace, VectorFile, VelloCanvasMaterial, VelloFont};
 use bevy::{
     prelude::*,
     render::{
@@ -61,6 +61,7 @@ pub fn render_scene(
     ss_render_target: Query<&SSRenderTarget>,
     render_vectors: Query<(&PreparedAffine, &ExtractedRenderVector)>,
     query_render_texts: Query<(&PreparedAffine, &ExtractedRenderText)>,
+    mut font_render_assets: ResMut<RenderAssets<VelloFont>>,
     gpu_images: Res<RenderAssets<Image>>,
     device: Res<RenderDevice>,
     queue: Res<RenderQueue>,
@@ -131,6 +132,7 @@ pub fn render_scene(
                     }
                     VectorFile::Lottie { composition } => {
                         debug!("playhead: {playhead}");
+
                         velottie_renderer.0.render(
                             {
                                 theme
@@ -149,7 +151,9 @@ pub fn render_scene(
                 RenderItem::Text(ExtractedRenderText {
                     font, text, ..
                 }) => {
-                    font.render(&mut scene, affine, text);
+                    if let Some(font) = font_render_assets.get_mut(font) {
+                        font.render(&mut scene, affine, text);
+                    }
                 }
             }
         }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -3,7 +3,7 @@ use bevy::{
     prelude::*,
     render::{
         mesh::Indices,
-        render_asset::RenderAssets,
+        render_asset::{RenderAssetUsages, RenderAssets},
         render_resource::{
             Extent3d, PrimitiveTopology, TextureDescriptor, TextureDimension,
             TextureFormat, TextureUsages,
@@ -61,7 +61,6 @@ pub fn render_scene(
     ss_render_target: Query<&SSRenderTarget>,
     render_vectors: Query<(&PreparedAffine, &ExtractedRenderVector)>,
     query_render_texts: Query<(&PreparedAffine, &ExtractedRenderText)>,
-    mut font_render_assets: ResMut<RenderAssets<VelloFont>>,
     gpu_images: Res<RenderAssets<Image>>,
     device: Res<RenderDevice>,
     queue: Res<RenderQueue>,
@@ -153,9 +152,7 @@ pub fn render_scene(
                 RenderItem::Text(ExtractedRenderText {
                     font, text, ..
                 }) => {
-                    if let Some(font) = font_render_assets.get_mut(font) {
-                        font.render(&mut builder, affine, text);
-                    }
+                    font.render(&mut builder, affine, text);
                 }
             }
         }
@@ -226,7 +223,10 @@ pub fn setup_ss_rendertarget(
     };
 
     let mesh_handle = render_target_mesh_handle.get_or_insert_with(|| {
-        let mut rendertarget_quad = Mesh::new(PrimitiveTopology::TriangleList);
+        let mut rendertarget_quad = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        );
 
         // Rectangle of the screen
         let verts = vec![
@@ -241,7 +241,7 @@ pub fn setup_ss_rendertarget(
         rendertarget_quad.insert_attribute(Mesh::ATTRIBUTE_UV_0, uv_pos);
 
         let indices = vec![0, 1, 2, 0, 2, 3];
-        rendertarget_quad.set_indices(Some(Indices::U32(indices)));
+        rendertarget_quad.insert_indices(Indices::U32(indices));
 
         meshes.add(rendertarget_quad)
     });

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -18,42 +18,15 @@ use super::vello_text::VelloText;
 use bevy::{prelude::*, reflect::TypePath, render::render_asset::RenderAsset};
 use std::sync::Arc;
 use vello::{
-    fello::{meta::MetadataProvider, raw::FontRef},
-    glyph::GlyphContext,
+    glyph::{skrifa::FontRef, GlyphContext},
     kurbo::Affine,
     peniko::{self, Blob, Brush, Font},
-    SceneBuilder, SceneFragment,
 };
 
 #[derive(Asset, TypePath)]
 pub struct VelloFont {
     gcx: GlyphContext,
     pub font: peniko::Font,
-}
-
-impl RenderAsset for VelloFont {
-    type ExtractedAsset = VelloFont;
-
-    type PreparedAsset = VelloFont;
-
-    type Param = ();
-
-    fn extract_asset(&self) -> Self::ExtractedAsset {
-        VelloFont {
-            font: self.font.clone(),
-            gcx: GlyphContext::default(),
-        }
-    }
-
-    fn prepare_asset(
-        data: Self::ExtractedAsset,
-        _param: &mut bevy::ecs::system::SystemParamItem<Self::Param>,
-    ) -> Result<
-        Self::PreparedAsset,
-        bevy::render::render_asset::PrepareAssetError<Self::ExtractedAsset>,
-    > {
-        Ok(data)
-    }
 }
 
 impl VelloFont {
@@ -68,11 +41,11 @@ impl VelloFont {
         let font = FontRef::new(self.font.data.data())
             .expect("Vello font creation error");
 
-        let fello_size = vello::fello::Size::new(text.size);
+        let font_size = vello::skrifa::instance::Size::new(text.size);
         let charmap = font.charmap();
-        let metrics = font.metrics(fello_size, Default::default());
+        let metrics = font.metrics(font_size, Default::default());
         let line_height = metrics.ascent - metrics.descent + metrics.leading;
-        let glyph_metrics = font.glyph_metrics(fello_size, Default::default());
+        let glyph_metrics = font.glyph_metrics(font_size, Default::default());
 
         let mut pen_x = 0.0;
         let mut pen_y: f32 = 0.0;
@@ -122,11 +95,11 @@ impl VelloFont {
 
         let mut items = vec![];
 
-        let fello_size = vello::fello::Size::new(size);
+        let font_size = vello::skrifa::instance::Size::new(size);
         let charmap = font.charmap();
-        let metrics = font.metrics(fello_size, Default::default());
+        let metrics = font.metrics(font_size, Default::default());
         let line_height = metrics.ascent - metrics.descent + metrics.leading;
-        let glyph_metrics = font.glyph_metrics(fello_size, Default::default());
+        let glyph_metrics = font.glyph_metrics(font_size, Default::default());
         let vars: [(&str, f32); 0] = [];
         let mut provider =
             self.gcx.new_provider(&font, None, size, false, vars);

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -15,12 +15,16 @@
 // Also licensed under MIT license, at your choice.
 
 use super::vello_text::VelloText;
-use bevy::{prelude::*, reflect::TypePath, render::render_asset::RenderAsset};
+use bevy::{prelude::*, reflect::TypePath};
 use std::sync::Arc;
 use vello::{
-    glyph::{skrifa::FontRef, GlyphContext},
+    glyph::{
+        skrifa::{FontRef, MetadataProvider},
+        Glyph, GlyphContext,
+    },
     kurbo::Affine,
-    peniko::{self, Blob, Brush, Font},
+    peniko::{self, Blob, Font},
+    Scene,
 };
 
 #[derive(Asset, TypePath)]
@@ -40,12 +44,14 @@ impl VelloFont {
     pub fn sizeof(&self, text: &VelloText) -> Vec2 {
         let font = FontRef::new(self.font.data.data())
             .expect("Vello font creation error");
-
         let font_size = vello::skrifa::instance::Size::new(text.size);
         let charmap = font.charmap();
-        let metrics = font.metrics(font_size, Default::default());
+        let axes = font.axes();
+        let variations: &[(&str, f32)] = &[];
+        let var_loc = axes.location(variations);
+        let metrics = font.metrics(font_size, &var_loc);
         let line_height = metrics.ascent - metrics.descent + metrics.leading;
-        let glyph_metrics = font.glyph_metrics(font_size, Default::default());
+        let glyph_metrics = font.glyph_metrics(font_size, &var_loc);
 
         let mut pen_x = 0.0;
         let mut pen_y: f32 = 0.0;
@@ -66,70 +72,51 @@ impl VelloFont {
         Vec2::new(width, height)
     }
 
-    pub fn render(
-        &mut self,
-        builder: &mut SceneBuilder,
+    pub(crate) fn render(
+        &self,
+        scene: &mut Scene,
         transform: Affine,
         text: &VelloText,
     ) {
-        let frags = self.render_fragments(
-            text.size,
-            text.brush.as_ref(),
-            transform,
-            &text.content,
-        );
-        for (glyph, transform) in frags {
-            builder.append(&glyph, Some(transform));
-        }
-    }
-
-    pub(crate) fn render_fragments(
-        &mut self,
-        size: f32,
-        brush: Option<&Brush>,
-        transform: Affine,
-        text: &str,
-    ) -> Vec<(SceneFragment, Affine)> {
         let font = FontRef::new(self.font.data.data())
             .expect("Vello font creation error");
 
-        let mut items = vec![];
-
-        let font_size = vello::skrifa::instance::Size::new(size);
+        let font_size = vello::skrifa::instance::Size::new(text.size);
         let charmap = font.charmap();
-        let metrics = font.metrics(font_size, Default::default());
+        let axes = font.axes();
+        let variations: &[(&str, f32)] = &[];
+        let var_loc = axes.location(variations);
+        let metrics = font.metrics(font_size, &var_loc);
         let line_height = metrics.ascent - metrics.descent + metrics.leading;
-        let glyph_metrics = font.glyph_metrics(font_size, Default::default());
-        let vars: [(&str, f32); 0] = [];
-        let mut provider =
-            self.gcx.new_provider(&font, None, size, false, vars);
+        let glyph_metrics = font.glyph_metrics(font_size, &var_loc);
 
-        let mut pen_x: f64 = 0.0;
-        let mut pen_y: f64 = 0.0;
-
-        for ch in text.chars() {
-            if ch == '\n' {
-                pen_y += line_height as f64;
-                pen_x = 0.0;
-                continue;
-            }
-            let gid = charmap.map(ch).unwrap_or_default();
-            let advance =
-                glyph_metrics.advance_width(gid).unwrap_or_default() as f64;
-
-            if let Some(glyph) = provider.get(gid.to_u16(), brush) {
-                let xform = transform
-                    * Affine::translate((pen_x, pen_y))
-                    * Affine::scale_non_uniform(1.0, -1.0);
-                // builder.append(&glyph, Some(xform));
-                items.push((glyph, xform));
-            }
-            pen_x += advance;
-        }
-        items
-            .into_iter()
-            // Push all lines up to account for new lines
-            .map(|(f, a)| (f, a * Affine::translate((0.0, pen_y))))
-            .collect()
+        let mut pen_x = 0f32;
+        let mut pen_y = 0f32;
+        scene
+            .draw_glyphs(&self.font)
+            .font_size(text.size)
+            .transform(transform)
+            .normalized_coords(var_loc.coords())
+            .brush(&text.brush.clone().unwrap_or_default())
+            .draw(
+                &vello::kurbo::Stroke::new(1.0),
+                text.content.chars().filter_map(|ch| {
+                    if ch == '\n' {
+                        pen_y += line_height;
+                        pen_x = 0.0;
+                        return None;
+                    }
+                    let gid = charmap.map(ch).unwrap_or_default();
+                    let advance =
+                        glyph_metrics.advance_width(gid).unwrap_or_default();
+                    let x = pen_x;
+                    pen_x += advance;
+                    Some(Glyph {
+                        id: gid.to_u16() as u32,
+                        x,
+                        y: pen_y,
+                    })
+                }),
+            )
     }
 }

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -1,43 +1,45 @@
-// Copyright 2022 The vello authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
-
 use super::vello_text::VelloText;
-use bevy::{prelude::*, reflect::TypePath};
+use bevy::{prelude::*, reflect::TypePath, render::render_asset::RenderAsset};
 use std::sync::Arc;
 use vello::{
     glyph::{
         skrifa::{FontRef, MetadataProvider},
-        Glyph, GlyphContext,
+        Glyph,
     },
     kurbo::Affine,
     peniko::{self, Blob, Font},
     Scene,
 };
 
-#[derive(Asset, TypePath)]
+#[derive(Asset, TypePath, Clone)]
 pub struct VelloFont {
-    gcx: GlyphContext,
-    pub font: peniko::Font,
+    pub font: Arc<peniko::Font>,
+}
+
+impl RenderAsset for VelloFont {
+    type PreparedAsset = VelloFont;
+
+    type Param = ();
+
+    fn asset_usage(&self) -> bevy::render::render_asset::RenderAssetUsages {
+        Default::default()
+    }
+
+    fn prepare_asset(
+        self,
+        _param: &mut bevy::ecs::system::SystemParamItem<Self::Param>,
+    ) -> Result<
+        Self::PreparedAsset,
+        bevy::render::render_asset::PrepareAssetError<Self>,
+    > {
+        Ok(self)
+    }
 }
 
 impl VelloFont {
     pub fn new(font_data: Vec<u8>) -> Self {
         Self {
-            gcx: GlyphContext::new(),
-            font: Font::new(Blob::new(Arc::new(font_data)), 0),
+            font: Arc::new(Font::new(Blob::new(Arc::new(font_data)), 0)),
         }
     }
 
@@ -47,8 +49,8 @@ impl VelloFont {
         let font_size = vello::skrifa::instance::Size::new(text.size);
         let charmap = font.charmap();
         let axes = font.axes();
-        let variations: &[(&str, f32)] = &[];
-        let var_loc = axes.location(variations);
+        const VARIATIONS: &[(&str, f32)] = &[];
+        let var_loc = axes.location(VARIATIONS);
         let metrics = font.metrics(font_size, &var_loc);
         let line_height = metrics.ascent - metrics.descent + metrics.leading;
         let glyph_metrics = font.glyph_metrics(font_size, &var_loc);
@@ -84,8 +86,8 @@ impl VelloFont {
         let font_size = vello::skrifa::instance::Size::new(text.size);
         let charmap = font.charmap();
         let axes = font.axes();
-        let variations: &[(&str, f32)] = &[];
-        let var_loc = axes.location(variations);
+        const VARIATIONS: &[(&str, f32)] = &[];
+        let var_loc = axes.location(VARIATIONS);
         let metrics = font.metrics(font_size, &var_loc);
         let line_height = metrics.ascent - metrics.descent + metrics.leading;
         let glyph_metrics = font.glyph_metrics(font_size, &var_loc);


### PR DESCRIPTION
Addresses #34 

Updating to bevy 0.13 requires updating vello to match wgpu versions with bevy. Updating vello comes with some challenges. SceneBuilder no longer exists. SceneFragment as well. vellottie and vello-svg likewise will need vello updates.

Also, bevy changed the ExtractComponent trait to where it didn't make sense for our uses in the VelloFont extract step, so it's being removed in favor of an extraction system like that used to make ExtractedRenderVector. So fonts should be regression tested. Vello no longer uses fello, instead reimports skifra-- all the font rendering abstraction on top of vello will need changed to support this, so lets pay close attention to fonts/text.