### PR TITLE
fix: missing default_font feature for diagnostic printing

### DIFF
--- a/examples/diagnostics/Cargo.toml
+++ b/examples/diagnostics/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy_vello = { path = "../../" }
-bevy = { workspace = true }
+bevy = { workspace = true, features = ["default_font"] }


### PR DESCRIPTION
Fixes a missing feature that allows text to render using the default font feature for the diagnostics example