### PR TITLE
fix: aabb calculation on asset load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This release supports Bevy version 0.17 and has an [MSRV][] of 1.87.
 ### Fixed
 
 - Updated velato to 0.8.0
+- AABBs are now correctly calculated on asset load
 
 ## [0.11.0] - 2025-12-08
 

--- a/src/integrations/lottie/plugin.rs
+++ b/src/integrations/lottie/plugin.rs
@@ -28,7 +28,10 @@ impl Plugin for LottieIntegrationPlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    systems::update_lottie_2d_aabb_on_change
+                    (
+                        systems::update_lottie_2d_aabb_on_asset_load,
+                        systems::update_lottie_2d_aabb_on_change,
+                    )
                         .in_set(bevy::camera::visibility::VisibilitySystems::CalculateBounds),
                     systems::update_ui_lottie_content_size_on_change
                         .in_set(bevy::ui::UiSystems::Content),

--- a/src/integrations/svg/plugin.rs
+++ b/src/integrations/svg/plugin.rs
@@ -24,7 +24,10 @@ impl Plugin for SvgIntegrationPlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    systems::update_svg_2d_aabb_on_change
+                    (
+                        systems::update_svg_2d_aabb_on_asset_load,
+                        systems::update_svg_2d_aabb_on_change,
+                    )
                         .in_set(bevy::camera::visibility::VisibilitySystems::CalculateBounds),
                     systems::update_ui_svg_content_size_on_change
                         .in_set(bevy::ui::UiSystems::Content),

--- a/src/integrations/text/plugin.rs
+++ b/src/integrations/text/plugin.rs
@@ -19,7 +19,10 @@ impl Plugin for VelloTextIntegrationPlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    systems::update_text_2d_aabb_on_change
+                    (
+                        systems::update_text_2d_aabb_on_asset_load,
+                        systems::update_text_2d_aabb_on_change,
+                    )
                         .in_set(bevy::camera::visibility::VisibilitySystems::CalculateBounds),
                     systems::update_ui_text_content_size_on_change
                         .in_set(bevy::ui::UiSystems::Content),

--- a/src/integrations/text/systems.rs
+++ b/src/integrations/text/systems.rs
@@ -1,44 +1,78 @@
+use crate::{VelloFont, prelude::*};
 use bevy::{
+    asset::AssetEvent,
     camera::primitives::Aabb,
     prelude::*,
     ui::{ContentSize, NodeMeasure},
 };
 
-use crate::{VelloFont, prelude::*};
+fn helper_calculate_aabb(
+    font: &VelloFont,
+    text: &VelloText2d,
+    text_anchor: &VelloTextAnchor,
+) -> Aabb {
+    let layout = font.layout(&text.value, &text.style, text.text_align, text.max_advance);
+    let (width, height) = (layout.width(), layout.height());
+    let half_size = Vec3::new(width / 2.0, height / 2.0, 0.0);
+    let (dx, dy) = {
+        match text_anchor {
+            VelloTextAnchor::TopLeft => (half_size.x, -half_size.y),
+            VelloTextAnchor::Left => (half_size.x, 0.0),
+            VelloTextAnchor::BottomLeft => (half_size.x, half_size.y),
+            VelloTextAnchor::Top => (0.0, -half_size.y),
+            VelloTextAnchor::Center => (0.0, 0.0),
+            VelloTextAnchor::Bottom => (0.0, half_size.y),
+            VelloTextAnchor::TopRight => (-half_size.x, -half_size.y),
+            VelloTextAnchor::Right => (-half_size.x, 0.0),
+            VelloTextAnchor::BottomRight => (-half_size.x, half_size.y),
+        }
+    };
+    let adjustment = Vec3::new(dx, dy, 0.0);
+    let min = -half_size + adjustment;
+    let max = half_size + adjustment;
+    Aabb::from_min_max(min, max)
+}
 
-pub fn update_text_2d_aabb_on_change(
-    mut text_q: Query<
-        (&mut Aabb, &mut VelloText2d, &VelloTextAnchor),
-        Or<(Changed<VelloText2d>, Changed<Transform>)>,
-    >,
+pub fn update_text_2d_aabb_on_asset_load(
+    mut asset_events: MessageReader<AssetEvent<VelloFont>>,
+    mut world_texts: Query<(&mut Aabb, &VelloText2d, &VelloTextAnchor)>,
     fonts: Res<Assets<VelloFont>>,
 ) {
-    for (mut aabb, text, text_anchor) in text_q.iter_mut() {
+    for event in asset_events.read() {
+        let id = if let AssetEvent::LoadedWithDependencies { id } = event {
+            *id
+        } else {
+            continue;
+        };
+        let Some((mut aabb, text, text_anchor)) = world_texts
+            .iter_mut()
+            .find(|(_, text, _)| text.style.font.id() == id)
+        else {
+            continue;
+        };
         let Some(font) = fonts.get(&text.style.font) else {
             // Not yet loaded
             continue;
         };
+        let new_aabb = helper_calculate_aabb(font, text, text_anchor);
+        *aabb = new_aabb;
+    }
+}
 
-        let layout = font.layout(&text.value, &text.style, text.text_align, text.max_advance);
-        let (width, height) = (layout.width(), layout.height());
-        let half_size = Vec3::new(width / 2.0, height / 2.0, 0.0);
-        let (dx, dy) = {
-            match text_anchor {
-                VelloTextAnchor::TopLeft => (half_size.x, -half_size.y),
-                VelloTextAnchor::Left => (half_size.x, 0.0),
-                VelloTextAnchor::BottomLeft => (half_size.x, half_size.y),
-                VelloTextAnchor::Top => (0.0, -half_size.y),
-                VelloTextAnchor::Center => (0.0, 0.0),
-                VelloTextAnchor::Bottom => (0.0, half_size.y),
-                VelloTextAnchor::TopRight => (-half_size.x, -half_size.y),
-                VelloTextAnchor::Right => (-half_size.x, 0.0),
-                VelloTextAnchor::BottomRight => (-half_size.x, half_size.y),
-            }
+pub fn update_text_2d_aabb_on_change(
+    mut world_texts: Query<
+        (&mut Aabb, &VelloText2d, &VelloTextAnchor),
+        Or<(Changed<VelloText2d>, Changed<Transform>)>,
+    >,
+    fonts: Res<Assets<VelloFont>>,
+) {
+    for (mut aabb, text, text_anchor) in world_texts.iter_mut() {
+        let Some(font) = fonts.get(&text.style.font) else {
+            // Not yet loaded
+            continue;
         };
-        let adjustment = Vec3::new(dx, dy, 0.0);
-        let min = -half_size + adjustment;
-        let max = half_size + adjustment;
-        *aabb = Aabb::from_min_max(min, max);
+        let new_aabb = helper_calculate_aabb(font, text, text_anchor);
+        *aabb = new_aabb;
     }
 }
 


### PR DESCRIPTION
Fixes a bug where AABBs do not get correctly calculated.

The demos worked because they are embedded assets (statically included, and hence, AABBs are calculable immediately)

Actual asset server loads are not always available on `Changed` so we need to add another observer-style callback to re-calc AABBs