### PR TITLE
fix: do not include `default_platform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,20 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 -->
 
-The latest published Bevy Vello release is [0.13.0](#0130---2026-01-29) which was released on 2026-01-29.
-You can find its changes [documented below](#0130---2026-01-29).
+The latest published Bevy Vello release is [0.13.1](#0131---2026-01-29) which was released on 2026-01-29.
+You can find its changes [documented below](#0131---2026-01-29).
 
 ## [Unreleased]
 
 This release supports Bevy version 0.18 and has an [MSRV][] of 1.87.
+
+## [0.13.1] - 2026-01-29
+
+This release supports Bevy version 0.18 and has an [MSRV][] of 1.87.
+
+### Fixed
+
+- `default_platform` is now no longer included with bevy_vello by default. If you brought this feature in your app as well, be sure to set the render creation `Backends` to omit WebGL2, as that is not compatible with Vello on web platforms. You may see an error in console such as `Too many bindings of type StorageBuffers in Stage ShaderStages(COMPUTE), limit is 0, count was 2.`.
 
 ## [0.13.0] - 2026-01-29
 
@@ -459,7 +467,8 @@ This release supports Bevy version 0.13 and has an [MSRV][] of 1.77.
 
 [@simbleau]: https://github.com/simbleau
 
-[Unreleased]: https://github.com/linebender/bevy_vello/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/linebender/bevy_vello/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/linebender/bevy_vello/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/linebender/bevy_vello/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/linebender/bevy_vello/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/linebender/bevy_vello/compare/v0.11.0...v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_vello"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "parley",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "cube3d"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -2347,7 +2347,7 @@ checksum = "edf215dbb8cb1409cca7645aaed35f9e39fb0a21855bba1ac48bc0334903bf66"
 
 [[package]]
 name = "diagnostics"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -2426,7 +2426,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "drag_n_drop"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_async_task",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "headless"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -3712,7 +3712,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lottie"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "lottie_player"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_egui",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "lottie_screenspace"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "lottie_ui"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "picking"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -4891,7 +4891,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "render_layers"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "scaling"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "scene"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "scene_screenspace"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "scene_ui"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5377,7 +5377,7 @@ dependencies = [
 
 [[package]]
 name = "svg"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5391,7 +5391,7 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "svg_screenspace"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "svg_ui"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5494,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "text"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",
@@ -5989,7 +5989,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "view_culling"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bevy",
  "bevy_vello",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.13.0"
+version = "0.13.1"
 rust-version = "1.87"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/linebender/bevy_vello"
@@ -33,7 +33,6 @@ repository = "https://github.com/linebender/bevy_vello"
 [workspace.dependencies]
 bevy = { version = "0.18.0", default-features = false, features = [
   "default_app",
-  "default_platform",
   "2d_bevy_render",
   "ui_bevy_render",
 ] }


### PR DESCRIPTION
`default_platform` erroneously includes WebGL by default. By default, it tries to use WebGL if the backend is not set.

This fix removes `default_platform` so it doesn't try to reach for it on accident. This will also fix the web demo at <https://linebender.org/bevy_vello>.

<img width="1486" height="916" alt="image" src="https://github.com/user-attachments/assets/4906dea2-c22c-4d81-b0e4-4ba12d61a371" />
