### PR TITLE
Add text layout cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This release supports Bevy version 0.18 and has an [MSRV][] of 1.87.
 
 - UI clip rect support: `CalculatedClip` is now respected for all UI Vello render types (`UiVelloScene`, `UiVelloSvg`, `UiVelloLottie`, `UiVelloText`), enabling proper overflow clipping.
 - Added `GLYPH_COUNT` and `GLYPH_RUN_COUNT` diagnostics per frame when the `text` feature is active.
+- Text layout cache: content-addressed double-buffer cache avoids redundant parley text shaping every frame.
 
 ### Fixed
 

--- a/src/integrations/text/font.rs
+++ b/src/integrations/text/font.rs
@@ -86,21 +86,21 @@ impl VelloFont {
         })
     }
 
+    /// Renders a pre-computed layout into the scene.
+    ///
+    /// Applies anchor offset, glyph-run culling, and glyph encoding.
+    /// Takes an existing `Layout<Brush>` so callers can reuse cached layouts.
     #[expect(clippy::too_many_arguments, reason = "Common lint in bevy")]
-    pub(crate) fn render(
+    pub(crate) fn render_with_layout(
         &self,
         scene: &mut Scene,
         mut transform: Affine,
-        value: &str,
+        layout: &Layout<Brush>,
         style: &VelloTextStyle,
-        text_align: VelloTextAlign,
-        max_advance: Option<f32>,
         text_anchor: VelloTextAnchor,
         ui_content: Option<Vec2>,
         clip: Option<vello::kurbo::Rect>,
     ) {
-        let layout = self.layout(value, style, text_align, max_advance);
-
         let text_w = layout.width() as f64;
         let text_h = layout.height() as f64;
 
@@ -362,9 +362,9 @@ pub(crate) fn compute_world_anchor_offset(
 
 /// Computes the (dx, dy) translation offset for UI text anchoring.
 ///
-/// Aligns text within the node's content box. The UiGlobalTransform places the
-/// origin at the node's center, so we compute offsets relative to that center
-/// to position text according to the anchor.
+/// Aligns text within the node's content box. The UiGlobalTransform places
+/// the origin at the node's top-left corner, so we compute offsets relative
+/// to that corner to position text according to the anchor.
 pub(crate) fn compute_ui_anchor_offset(
     text_anchor: VelloTextAnchor,
     text_w: f64,

--- a/src/integrations/text/layout_cache.rs
+++ b/src/integrations/text/layout_cache.rs
@@ -1,0 +1,301 @@
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+use bevy::prelude::*;
+use parley::Layout;
+use vello::peniko::Brush;
+
+use super::{VelloFont, VelloTextAlign, VelloTextStyle};
+
+/// Content-addressed key for cached text layouts.
+///
+/// Uses SipHash of (font_id, text_value, style fields, text_align, max_advance).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TextLayoutKey(pub u64);
+
+impl TextLayoutKey {
+    pub fn new(
+        font_id: AssetId<VelloFont>,
+        value: &str,
+        style: &VelloTextStyle,
+        text_align: VelloTextAlign,
+        max_advance: Option<f32>,
+    ) -> Self {
+        let mut hasher = std::hash::DefaultHasher::new();
+        font_id.hash(&mut hasher);
+        value.hash(&mut hasher);
+        // Hash style fields that affect layout
+        style.font_size.to_bits().hash(&mut hasher);
+        style.line_height.to_bits().hash(&mut hasher);
+        style.word_spacing.to_bits().hash(&mut hasher);
+        style.letter_spacing.to_bits().hash(&mut hasher);
+        // Hash font axes
+        style.font_axes.weight.map(f32::to_bits).hash(&mut hasher);
+        style.font_axes.width.map(f32::to_bits).hash(&mut hasher);
+        style
+            .font_axes
+            .optical_size
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        style.font_axes.italic.hash(&mut hasher);
+        style.font_axes.slant.map(f32::to_bits).hash(&mut hasher);
+        style.font_axes.grade.map(f32::to_bits).hash(&mut hasher);
+        style
+            .font_axes
+            .thick_stroke
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        style
+            .font_axes
+            .thin_stroke
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        style
+            .font_axes
+            .counter_width
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        style
+            .font_axes
+            .uppercase_height
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        style
+            .font_axes
+            .lowercase_height
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        style
+            .font_axes
+            .ascender_height
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        style
+            .font_axes
+            .descender_depth
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        style
+            .font_axes
+            .figure_height
+            .map(f32::to_bits)
+            .hash(&mut hasher);
+        text_align.hash(&mut hasher);
+        max_advance.map(f32::to_bits).hash(&mut hasher);
+        Self(hasher.finish())
+    }
+}
+
+/// Double-buffered content-addressed cache for parley text layouts.
+///
+/// Lives in the render world. Each frame, lookups check `previous` and promote
+/// hits into `current`. At the start of the next frame, `previous` is drained
+/// (its allocation reused) and the buffers swap. Entries not touched for one
+/// frame are naturally dropped — no periodic sweep, no variable-cost pass.
+///
+/// `Layout<Brush>` clones are cheap because parley's font data uses `Arc`
+/// internally.
+#[derive(Resource, Default)]
+pub struct TextLayoutCache {
+    /// Entries promoted (or newly inserted) this frame.
+    current: HashMap<TextLayoutKey, Layout<Brush>>,
+    /// Last frame's entries, used as a read-only lookup source.
+    previous: HashMap<TextLayoutKey, Layout<Brush>>,
+}
+
+impl TextLayoutCache {
+    /// Returns a cached layout or inserts one computed by the closure.
+    ///
+    /// Checks `current` first (already promoted this frame), then `previous`.
+    /// On miss, calls the closure and inserts into `current`.
+    pub fn get_or_insert_with(
+        &mut self,
+        key: TextLayoutKey,
+        f: impl FnOnce() -> Layout<Brush>,
+    ) -> Layout<Brush> {
+        // Already promoted this frame — fast path.
+        if let Some(layout) = self.current.get(&key) {
+            return layout.clone();
+        }
+
+        // Promote from previous frame's buffer.
+        if let Some(layout) = self.previous.remove(&key) {
+            self.current.insert(key, layout.clone());
+            return layout;
+        }
+
+        // Cache miss — compute and insert.
+        let layout = f();
+        self.current.insert(key, layout.clone());
+        layout
+    }
+
+    /// Rotate buffers: drain `previous` (keeping its allocation), swap.
+    ///
+    /// Call once at the start of each frame. Anything left in `previous`
+    /// was unused last frame and is dropped here.
+    pub fn advance_frame(&mut self) {
+        self.previous.clear();
+        std::mem::swap(&mut self.current, &mut self.previous);
+    }
+
+    /// Drop all cached layouts (e.g. when font assets change).
+    pub fn clear(&mut self) {
+        self.current.clear();
+        self.previous.clear();
+    }
+
+    /// Number of cached layouts across both buffers.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.current.len() + self.previous.len()
+    }
+
+    /// Number of layouts in the current (promoted) buffer.
+    #[cfg(test)]
+    fn current_len(&self) -> usize {
+        self.current.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn make_key(n: u64) -> TextLayoutKey {
+        TextLayoutKey(n)
+    }
+
+    /// Second call with the same key must not invoke the closure.
+    #[test]
+    fn cache_hit_skips_closure() {
+        let mut cache = TextLayoutCache::default();
+        let key = make_key(42);
+
+        let call_count = Cell::new(0u32);
+        let _layout = cache.get_or_insert_with(key, || {
+            call_count.set(call_count.get() + 1);
+            Layout::new()
+        });
+        assert_eq!(call_count.get(), 1);
+
+        let _layout = cache.get_or_insert_with(key, || {
+            call_count.set(call_count.get() + 1);
+            Layout::new()
+        });
+        assert_eq!(call_count.get(), 1, "closure must not run on cache hit");
+    }
+
+    /// Different keys produce independent cache entries.
+    #[test]
+    fn different_keys_are_independent() {
+        let mut cache = TextLayoutCache::default();
+
+        cache.get_or_insert_with(make_key(1), Layout::new);
+        cache.get_or_insert_with(make_key(2), Layout::new);
+        assert_eq!(cache.current_len(), 2);
+
+        // Re-request key 1 — still 2 entries, no new insertion.
+        cache.get_or_insert_with(make_key(1), || panic!("should be cached"));
+        assert_eq!(cache.current_len(), 2);
+    }
+
+    /// After advance_frame, entries move to `previous` and are still
+    /// accessible. After two advances without access, they're gone.
+    #[test]
+    fn entry_survives_one_idle_frame() {
+        let mut cache = TextLayoutCache::default();
+        cache.get_or_insert_with(make_key(1), Layout::new);
+        assert_eq!(cache.current_len(), 1);
+
+        // Advance: entry moves to previous, still reachable.
+        cache.advance_frame();
+        assert_eq!(cache.current_len(), 0);
+        assert_eq!(cache.len(), 1);
+
+        // Access promotes it back to current.
+        cache.get_or_insert_with(make_key(1), || panic!("should be in previous"));
+        assert_eq!(cache.current_len(), 1);
+    }
+
+    /// An entry not accessed for two frames is evicted.
+    #[test]
+    fn entry_evicted_after_two_idle_frames() {
+        let mut cache = TextLayoutCache::default();
+        cache.get_or_insert_with(make_key(1), Layout::new);
+
+        cache.advance_frame(); // current→previous
+        cache.advance_frame(); // previous cleared, old entry dropped
+        assert_eq!(
+            cache.len(),
+            0,
+            "entry should be evicted after 2 idle frames"
+        );
+    }
+
+    /// `clear()` removes all entries immediately.
+    #[test]
+    fn clear_removes_all_entries() {
+        let mut cache = TextLayoutCache::default();
+        cache.get_or_insert_with(make_key(1), Layout::new);
+        cache.advance_frame();
+        cache.get_or_insert_with(make_key(2), Layout::new);
+        assert_eq!(cache.len(), 2);
+
+        cache.clear();
+        assert_eq!(cache.len(), 0);
+    }
+
+    /// `TextLayoutKey::new` produces different keys for different text content.
+    #[test]
+    fn key_differs_on_text_content() {
+        let style = VelloTextStyle::default();
+        let font_id = AssetId::<VelloFont>::default();
+
+        let key_a = TextLayoutKey::new(font_id, "hello", &style, VelloTextAlign::Start, None);
+        let key_b = TextLayoutKey::new(font_id, "world", &style, VelloTextAlign::Start, None);
+        assert_ne!(key_a, key_b);
+    }
+
+    /// Same inputs produce the same key (deterministic).
+    #[test]
+    fn key_stable_for_same_inputs() {
+        let style = VelloTextStyle::default();
+        let font_id = AssetId::<VelloFont>::default();
+
+        let key_a = TextLayoutKey::new(font_id, "hello", &style, VelloTextAlign::Start, None);
+        let key_b = TextLayoutKey::new(font_id, "hello", &style, VelloTextAlign::Start, None);
+        assert_eq!(key_a, key_b);
+    }
+
+    /// Brush (text color) is intentionally excluded from the cache key
+    /// because it does not affect text layout geometry.
+    #[test]
+    fn key_ignores_brush_color() {
+        let font_id = AssetId::<VelloFont>::default();
+        let mut style_white = VelloTextStyle::default();
+        style_white.brush = vello::peniko::Brush::Solid(vello::peniko::Color::WHITE);
+        let mut style_red = VelloTextStyle::default();
+        style_red.brush =
+            vello::peniko::Brush::Solid(vello::peniko::Color::new([1.0, 0.0, 0.0, 1.0]));
+
+        let key_a = TextLayoutKey::new(font_id, "hello", &style_white, VelloTextAlign::Start, None);
+        let key_b = TextLayoutKey::new(font_id, "hello", &style_red, VelloTextAlign::Start, None);
+        assert_eq!(key_a, key_b, "brush must not affect layout cache key");
+    }
+
+    /// Key changes when style fields change.
+    #[test]
+    fn key_differs_on_font_size() {
+        let font_id = AssetId::<VelloFont>::default();
+        let mut style_a = VelloTextStyle::default();
+        style_a.font_size = 16.0;
+        let mut style_b = VelloTextStyle::default();
+        style_b.font_size = 32.0;
+
+        let key_a = TextLayoutKey::new(font_id, "hi", &style_a, VelloTextAlign::Start, None);
+        let key_b = TextLayoutKey::new(font_id, "hi", &style_b, VelloTextAlign::Start, None);
+        assert_ne!(key_a, key_b);
+    }
+}

--- a/src/integrations/text/layout_cache.rs
+++ b/src/integrations/text/layout_cache.rs
@@ -9,9 +9,15 @@ use super::{VelloFont, VelloTextAlign, VelloTextStyle};
 
 /// Content-addressed key for cached text layouts.
 ///
-/// Uses SipHash of (font_id, text_value, style fields, text_align, max_advance).
+/// Stores the `font_id` alongside a SipHash of (font_id, text, style, align,
+/// max_advance).  The hash drives equality/lookup; the `font_id` enables
+/// targeted eviction when a single font asset changes without clearing the
+/// entire cache.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct TextLayoutKey(pub u64);
+pub struct TextLayoutKey {
+    pub font_id: AssetId<VelloFont>,
+    pub hash: u64,
+}
 
 impl TextLayoutKey {
     pub fn new(
@@ -82,7 +88,10 @@ impl TextLayoutKey {
             .hash(&mut hasher);
         text_align.hash(&mut hasher);
         max_advance.map(f32::to_bits).hash(&mut hasher);
-        Self(hasher.finish())
+        Self {
+            font_id,
+            hash: hasher.finish(),
+        }
     }
 }
 
@@ -139,10 +148,13 @@ impl TextLayoutCache {
         std::mem::swap(&mut self.current, &mut self.previous);
     }
 
-    /// Drop all cached layouts (e.g. when font assets change).
-    pub fn clear(&mut self) {
-        self.current.clear();
-        self.previous.clear();
+    /// Evict all cached layouts that used `font_id`.
+    ///
+    /// Called when a font asset is modified or removed so that only the
+    /// affected layouts are recomputed, not the entire cache.
+    pub fn evict_font(&mut self, font_id: AssetId<VelloFont>) {
+        self.current.retain(|k, _| k.font_id != font_id);
+        self.previous.retain(|k, _| k.font_id != font_id);
     }
 
     /// Number of cached layouts across both buffers.
@@ -164,7 +176,10 @@ mod tests {
     use std::cell::Cell;
 
     fn make_key(n: u64) -> TextLayoutKey {
-        TextLayoutKey(n)
+        TextLayoutKey {
+            font_id: AssetId::<VelloFont>::default(),
+            hash: n,
+        }
     }
 
     /// Second call with the same key must not invoke the closure.
@@ -234,17 +249,53 @@ mod tests {
         );
     }
 
-    /// `clear()` removes all entries immediately.
+    fn make_font_key(font_id: AssetId<VelloFont>, n: u64) -> TextLayoutKey {
+        TextLayoutKey { font_id, hash: n }
+    }
+
+    /// `evict_font` removes only entries for the given font.
     #[test]
-    fn clear_removes_all_entries() {
+    fn evict_font_is_selective() {
         let mut cache = TextLayoutCache::default();
-        cache.get_or_insert_with(make_key(1), Layout::new);
-        cache.advance_frame();
-        cache.get_or_insert_with(make_key(2), Layout::new);
+        let font_a = AssetId::<VelloFont>::Uuid {
+            uuid: bevy::asset::uuid::Uuid::from_u128(1),
+        };
+        let font_b = AssetId::<VelloFont>::Uuid {
+            uuid: bevy::asset::uuid::Uuid::from_u128(2),
+        };
+
+        let key_a = make_font_key(font_a, 100);
+        let key_b = make_font_key(font_b, 200);
+
+        cache.get_or_insert_with(key_a, Layout::new);
+        cache.get_or_insert_with(key_b, Layout::new);
         assert_eq!(cache.len(), 2);
 
-        cache.clear();
-        assert_eq!(cache.len(), 0);
+        cache.evict_font(font_a);
+        assert_eq!(cache.len(), 1, "only font_a entries should be evicted");
+
+        // font_b entry still accessible.
+        cache.get_or_insert_with(key_b, || panic!("font_b should still be cached"));
+    }
+
+    /// `evict_font` removes entries from both buffers.
+    #[test]
+    fn evict_font_spans_both_buffers() {
+        let mut cache = TextLayoutCache::default();
+        let font_a = AssetId::<VelloFont>::Uuid {
+            uuid: bevy::asset::uuid::Uuid::from_u128(1),
+        };
+        let font_b = AssetId::<VelloFont>::Uuid {
+            uuid: bevy::asset::uuid::Uuid::from_u128(2),
+        };
+
+        cache.get_or_insert_with(make_font_key(font_a, 10), Layout::new);
+        cache.advance_frame(); // font_a entry moves to previous
+        cache.get_or_insert_with(make_font_key(font_b, 20), Layout::new); // in current
+
+        assert_eq!(cache.len(), 2);
+        cache.evict_font(font_a);
+        assert_eq!(cache.len(), 1, "font_a in previous should be evicted");
     }
 
     /// `TextLayoutKey::new` produces different keys for different text content.

--- a/src/integrations/text/mod.rs
+++ b/src/integrations/text/mod.rs
@@ -3,6 +3,7 @@
 mod context;
 mod font;
 mod font_loader;
+pub(crate) mod layout_cache;
 mod systems;
 
 pub(crate) mod render;
@@ -172,7 +173,7 @@ pub enum VelloTextAnchor {
 }
 
 /// Alignment of a parley layout.
-#[derive(Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VelloTextAlign {
     /// This is [`parley::Alignment::Left`] for LTR text and [`parley::Alignment::Right`] for RTL
     /// text.

--- a/src/integrations/text/render.rs
+++ b/src/integrations/text/render.rs
@@ -8,7 +8,7 @@ use bevy::{
 };
 use vello::kurbo::Affine;
 
-use super::{UiVelloText, VelloFont, VelloText2d, VelloTextAnchor};
+use super::{UiVelloText, VelloFont, VelloText2d, VelloTextAnchor, layout_cache::TextLayoutKey};
 use crate::render::{VelloEntityCountData, VelloView, prepare::PreparedAffine};
 
 #[derive(Component, Clone)]
@@ -16,6 +16,7 @@ pub struct ExtractedVelloText2d {
     pub text: VelloText2d,
     pub text_anchor: VelloTextAnchor,
     pub transform: GlobalTransform,
+    pub content_hash: u64,
 }
 
 #[derive(Component, Clone)]
@@ -26,6 +27,7 @@ pub struct ExtractedUiVelloText {
     pub ui_node: ComputedNode,
     pub ui_render_target: ComputedUiRenderTargetInfo,
     pub clip: Option<Rect>,
+    pub content_hash: u64,
 }
 
 pub fn extract_world_text(
@@ -73,11 +75,20 @@ pub fn extract_world_text(
         if views.iter().any(|(_, camera_layers)| {
             asset_render_layers.intersects(camera_layers.unwrap_or_default())
         }) {
+            let content_hash = TextLayoutKey::new(
+                text.style.font.id(),
+                &text.value,
+                &text.style,
+                text.text_align,
+                text.max_advance,
+            )
+            .0;
             commands
                 .spawn(ExtractedVelloText2d {
                     text: text.clone(),
                     text_anchor: *text_anchor,
                     transform: *transform,
+                    content_hash,
                 })
                 .insert(TemporaryRenderEntity);
             n_texts += 1;
@@ -141,6 +152,14 @@ pub fn extract_ui_text(
         if views.iter().any(|(_, camera_layers)| {
             asset_render_layers.intersects(camera_layers.unwrap_or_default())
         }) {
+            let content_hash = TextLayoutKey::new(
+                text.style.font.id(),
+                &text.value,
+                &text.style,
+                text.text_align,
+                text.max_advance,
+            )
+            .0;
             commands
                 .spawn(ExtractedUiVelloText {
                     text: text.clone(),
@@ -149,6 +168,7 @@ pub fn extract_ui_text(
                     ui_node: *ui_node,
                     ui_render_target: *ui_render_target,
                     clip: calc_clip.map(|c| c.clip),
+                    content_hash,
                 })
                 .insert(TemporaryRenderEntity);
             n_texts += 1;

--- a/src/integrations/text/render.rs
+++ b/src/integrations/text/render.rs
@@ -16,7 +16,7 @@ pub struct ExtractedVelloText2d {
     pub text: VelloText2d,
     pub text_anchor: VelloTextAnchor,
     pub transform: GlobalTransform,
-    pub content_hash: u64,
+    pub cache_key: TextLayoutKey,
 }
 
 #[derive(Component, Clone)]
@@ -27,7 +27,7 @@ pub struct ExtractedUiVelloText {
     pub ui_node: ComputedNode,
     pub ui_render_target: ComputedUiRenderTargetInfo,
     pub clip: Option<Rect>,
-    pub content_hash: u64,
+    pub cache_key: TextLayoutKey,
 }
 
 pub fn extract_world_text(
@@ -75,20 +75,19 @@ pub fn extract_world_text(
         if views.iter().any(|(_, camera_layers)| {
             asset_render_layers.intersects(camera_layers.unwrap_or_default())
         }) {
-            let content_hash = TextLayoutKey::new(
+            let cache_key = TextLayoutKey::new(
                 text.style.font.id(),
                 &text.value,
                 &text.style,
                 text.text_align,
                 text.max_advance,
-            )
-            .0;
+            );
             commands
                 .spawn(ExtractedVelloText2d {
                     text: text.clone(),
                     text_anchor: *text_anchor,
                     transform: *transform,
-                    content_hash,
+                    cache_key,
                 })
                 .insert(TemporaryRenderEntity);
             n_texts += 1;
@@ -152,14 +151,13 @@ pub fn extract_ui_text(
         if views.iter().any(|(_, camera_layers)| {
             asset_render_layers.intersects(camera_layers.unwrap_or_default())
         }) {
-            let content_hash = TextLayoutKey::new(
+            let cache_key = TextLayoutKey::new(
                 text.style.font.id(),
                 &text.value,
                 &text.style,
                 text.text_align,
                 text.max_advance,
-            )
-            .0;
+            );
             commands
                 .spawn(ExtractedUiVelloText {
                     text: text.clone(),
@@ -168,7 +166,7 @@ pub fn extract_ui_text(
                     ui_node: *ui_node,
                     ui_render_target: *ui_render_target,
                     clip: calc_clip.map(|c| c.clip),
-                    content_hash,
+                    cache_key,
                 })
                 .insert(TemporaryRenderEntity);
             n_texts += 1;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -256,6 +256,12 @@ pub(crate) struct VelloEntityCountData {
     pub n_ui_lotties: u32,
 }
 
+/// Signals to the render world that font assets changed and the text layout
+/// cache should be invalidated.
+#[cfg(feature = "text")]
+#[derive(Resource, Clone, Default)]
+pub(crate) struct VelloFontChanged(pub bool);
+
 /// Internally used for diagnostics.
 #[derive(Resource, Default, Debug, Clone, Reflect)]
 pub(crate) struct VelloFrameProfileData {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -256,11 +256,11 @@ pub(crate) struct VelloEntityCountData {
     pub n_ui_lotties: u32,
 }
 
-/// Signals to the render world that font assets changed and the text layout
-/// cache should be invalidated.
+/// Carries the set of font asset IDs that changed this frame so the render
+/// world can evict only the affected text layout cache entries.
 #[cfg(feature = "text")]
 #[derive(Resource, Clone, Default)]
-pub(crate) struct VelloFontChanged(pub bool);
+pub(crate) struct VelloFontsChanged(pub Vec<AssetId<crate::integrations::text::VelloFont>>);
 
 /// Internally used for diagnostics.
 #[derive(Resource, Default, Debug, Clone, Reflect)]

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -9,6 +9,8 @@ use bevy::{
     sprite_render::Material2dPlugin,
 };
 
+#[cfg(feature = "text")]
+use super::VelloFontChanged;
 use super::{VelloCanvasSettings, VelloRenderSettings, extract::VelloRenderTarget, systems};
 use crate::{
     VelloView,
@@ -18,6 +20,8 @@ use crate::{
         extract::VelloExtractStep,
     },
 };
+#[cfg(feature = "text")]
+use bevy::render::MainWorld;
 
 #[derive(Default)]
 pub struct VelloRenderPlugin {
@@ -40,6 +44,10 @@ impl Plugin for VelloRenderPlugin {
         // Diagnostics
         app.add_plugins(VelloRenderDiagnosticsPlugin);
 
+        #[cfg(feature = "text")]
+        app.init_resource::<VelloFontChanged>()
+            .add_systems(PostUpdate, systems::detect_font_changes);
+
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
@@ -48,7 +56,16 @@ impl Plugin for VelloRenderPlugin {
             .insert_resource(self.render_settings.clone())
             .init_resource::<VelloEntityCountData>()
             .init_resource::<VelloFrameProfileData>()
-            .init_resource::<VelloRenderQueue>()
+            .init_resource::<VelloRenderQueue>();
+        #[cfg(feature = "text")]
+        render_app
+            .init_resource::<VelloFontChanged>()
+            .init_resource::<crate::integrations::text::layout_cache::TextLayoutCache>()
+            .add_systems(
+                ExtractSchedule,
+                extract_font_changed.after(VelloExtractStep::ExtractAssets),
+            );
+        render_app
             .configure_sets(
                 ExtractSchedule,
                 (
@@ -89,5 +106,13 @@ impl Plugin for VelloRenderPlugin {
             return;
         };
         render_app.init_resource::<VelloRenderer>();
+    }
+}
+
+/// Copies [`VelloFontChanged`] from the main world into the render world.
+#[cfg(feature = "text")]
+fn extract_font_changed(main_world: Res<MainWorld>, mut font_changed: ResMut<VelloFontChanged>) {
+    if let Some(main_font_changed) = main_world.get_resource::<VelloFontChanged>() {
+        font_changed.0 = main_font_changed.0;
     }
 }

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -10,7 +10,7 @@ use bevy::{
 };
 
 #[cfg(feature = "text")]
-use super::VelloFontChanged;
+use super::VelloFontsChanged;
 use super::{VelloCanvasSettings, VelloRenderSettings, extract::VelloRenderTarget, systems};
 use crate::{
     VelloView,
@@ -45,7 +45,7 @@ impl Plugin for VelloRenderPlugin {
         app.add_plugins(VelloRenderDiagnosticsPlugin);
 
         #[cfg(feature = "text")]
-        app.init_resource::<VelloFontChanged>()
+        app.init_resource::<VelloFontsChanged>()
             .add_systems(PostUpdate, systems::detect_font_changes);
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
@@ -59,7 +59,7 @@ impl Plugin for VelloRenderPlugin {
             .init_resource::<VelloRenderQueue>();
         #[cfg(feature = "text")]
         render_app
-            .init_resource::<VelloFontChanged>()
+            .init_resource::<VelloFontsChanged>()
             .init_resource::<crate::integrations::text::layout_cache::TextLayoutCache>()
             .add_systems(
                 ExtractSchedule,
@@ -109,10 +109,12 @@ impl Plugin for VelloRenderPlugin {
     }
 }
 
-/// Copies [`VelloFontChanged`] from the main world into the render world.
+/// Copies [`VelloFontsChanged`] from the main world into the render world.
 #[cfg(feature = "text")]
-fn extract_font_changed(main_world: Res<MainWorld>, mut font_changed: ResMut<VelloFontChanged>) {
-    if let Some(main_font_changed) = main_world.get_resource::<VelloFontChanged>() {
-        font_changed.0 = main_font_changed.0;
+fn extract_font_changed(main_world: Res<MainWorld>, mut font_changed: ResMut<VelloFontsChanged>) {
+    if let Some(main_font_changed) = main_world.get_resource::<VelloFontsChanged>() {
+        font_changed.0.clone_from(&main_font_changed.0);
+    } else {
+        font_changed.0.clear();
     }
 }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -272,6 +272,10 @@ pub fn sort_render_items(
 pub fn render_frame(
     render_target: Single<&VelloRenderTarget>,
     #[cfg(feature = "text")] font_render_assets: Res<RenderAssets<VelloFont>>,
+    #[cfg(feature = "text")] mut text_layout_cache: ResMut<
+        crate::integrations::text::layout_cache::TextLayoutCache,
+    >,
+    #[cfg(feature = "text")] font_changed: Res<super::VelloFontChanged>,
     gpu_images: Res<RenderAssets<GpuImage>>,
     device: Res<RenderDevice>,
     queue: Res<RenderQueue>,
@@ -281,6 +285,14 @@ pub fn render_frame(
     render_queue: Res<VelloRenderQueue>,
     mut frame_profile: ResMut<VelloFrameProfileData>,
 ) {
+    #[cfg(feature = "text")]
+    {
+        if font_changed.0 {
+            text_layout_cache.clear();
+        }
+        text_layout_cache.advance_frame();
+    }
+
     let VelloRenderTarget(render_target_image) = *render_target;
     let gpu_image = gpu_images.get(render_target_image).unwrap();
 
@@ -364,17 +376,22 @@ pub fn render_frame(
                 affine,
                 item:
                     ExtractedVelloText2d {
-                        text, text_anchor, ..
+                        text,
+                        text_anchor,
+                        content_hash,
+                        ..
                     },
             } => {
                 if let Some(font) = font_render_assets.get(text.style.font.id()) {
-                    font.render(
+                    let key = crate::integrations::text::layout_cache::TextLayoutKey(*content_hash);
+                    let layout = text_layout_cache.get_or_insert_with(key, || {
+                        font.layout(&text.value, &text.style, text.text_align, text.max_advance)
+                    });
+                    font.render_with_layout(
                         &mut scene_buffer,
                         *affine,
-                        &text.value,
+                        &layout,
                         &text.style,
-                        text.text_align,
-                        text.max_advance,
                         *text_anchor,
                         None,
                         None,
@@ -496,18 +513,21 @@ pub fn render_frame(
                         text_anchor,
                         ui_node,
                         ui_render_target,
+                        content_hash,
                         ..
                     },
             } => {
                 if let Some(font) = font_render_assets.get(text.style.font.id()) {
                     let logical_size = ui_node.size() / ui_render_target.scale_factor();
-                    font.render(
+                    let key = crate::integrations::text::layout_cache::TextLayoutKey(*content_hash);
+                    let layout = text_layout_cache.get_or_insert_with(key, || {
+                        font.layout(&text.value, &text.style, text.text_align, text.max_advance)
+                    });
+                    font.render_with_layout(
                         &mut scene_buffer,
                         *affine,
-                        &text.value,
+                        &layout,
                         &text.style,
-                        text.text_align,
-                        text.max_advance,
                         *text_anchor,
                         Some(logical_size),
                         *clip,
@@ -674,4 +694,17 @@ pub fn render_settings_change_detection(
         commands.remove_resource::<VelloRenderer>();
         commands.init_resource::<VelloRenderer>();
     }
+}
+
+/// Sets [`VelloFontChanged`] when font assets are added, modified, or removed.
+///
+/// The render world uses this to invalidate the text layout cache.
+#[cfg(feature = "text")]
+pub fn detect_font_changes(
+    mut font_changed: ResMut<super::VelloFontChanged>,
+    mut font_events: bevy::ecs::message::MessageReader<
+        AssetEvent<crate::integrations::text::VelloFont>,
+    >,
+) {
+    font_changed.0 = font_events.read().count() > 0;
 }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -275,7 +275,7 @@ pub fn render_frame(
     #[cfg(feature = "text")] mut text_layout_cache: ResMut<
         crate::integrations::text::layout_cache::TextLayoutCache,
     >,
-    #[cfg(feature = "text")] font_changed: Res<super::VelloFontChanged>,
+    #[cfg(feature = "text")] fonts_changed: Res<super::VelloFontsChanged>,
     gpu_images: Res<RenderAssets<GpuImage>>,
     device: Res<RenderDevice>,
     queue: Res<RenderQueue>,
@@ -287,8 +287,8 @@ pub fn render_frame(
 ) {
     #[cfg(feature = "text")]
     {
-        if font_changed.0 {
-            text_layout_cache.clear();
+        for &font_id in &fonts_changed.0 {
+            text_layout_cache.evict_font(font_id);
         }
         text_layout_cache.advance_frame();
     }
@@ -378,12 +378,12 @@ pub fn render_frame(
                     ExtractedVelloText2d {
                         text,
                         text_anchor,
-                        content_hash,
+                        cache_key,
                         ..
                     },
             } => {
                 if let Some(font) = font_render_assets.get(text.style.font.id()) {
-                    let key = crate::integrations::text::layout_cache::TextLayoutKey(*content_hash);
+                    let key = *cache_key;
                     let layout = text_layout_cache.get_or_insert_with(key, || {
                         font.layout(&text.value, &text.style, text.text_align, text.max_advance)
                     });
@@ -513,13 +513,13 @@ pub fn render_frame(
                         text_anchor,
                         ui_node,
                         ui_render_target,
-                        content_hash,
+                        cache_key,
                         ..
                     },
             } => {
                 if let Some(font) = font_render_assets.get(text.style.font.id()) {
                     let logical_size = ui_node.size() / ui_render_target.scale_factor();
-                    let key = crate::integrations::text::layout_cache::TextLayoutKey(*content_hash);
+                    let key = *cache_key;
                     let layout = text_layout_cache.get_or_insert_with(key, || {
                         font.layout(&text.value, &text.style, text.text_align, text.max_advance)
                     });
@@ -696,15 +696,25 @@ pub fn render_settings_change_detection(
     }
 }
 
-/// Sets [`VelloFontChanged`] when font assets are added, modified, or removed.
+/// Collects the IDs of font assets that were modified or removed this frame.
 ///
-/// The render world uses this to invalidate the text layout cache.
+/// The render world uses these to selectively evict text layout cache entries
+/// for the affected fonts, rather than clearing the entire cache.
 #[cfg(feature = "text")]
 pub fn detect_font_changes(
-    mut font_changed: ResMut<super::VelloFontChanged>,
+    mut fonts_changed: ResMut<super::VelloFontsChanged>,
     mut font_events: bevy::ecs::message::MessageReader<
         AssetEvent<crate::integrations::text::VelloFont>,
     >,
 ) {
-    font_changed.0 = font_events.read().count() > 0;
+    fonts_changed.0.clear();
+    for event in font_events.read() {
+        let id = match event {
+            AssetEvent::Modified { id } | AssetEvent::Removed { id } => *id,
+            _ => continue,
+        };
+        if !fonts_changed.0.contains(&id) {
+            fonts_changed.0.push(id);
+        }
+    }
 }


### PR DESCRIPTION
Parley text shaping is the most expensive part of large text scenes due to performing layout every frame. With caching, the most expensive part of scenes with lots of text can be skipped. The cache is content-addressed and expires automatically.

Changes:

- TextLayoutCache: content-addressed double-buffer cache for parley text layouts in the render world. Keyed by font, text content, style
  fields, alignment, and max_advance. Unaccessed entries drop after one idle frame via buffer rotation — no configuration needed.
- VelloFontChanged: resource that clears the cache when font assets change. Fully gated behind #[cfg(feature = "text")].
- GLYPH_COUNT / GLYPH_RUN_COUNT diagnostics when text feature is active.
- render_with_layout(): splits layout computation from glyph encoding so callers can pass cached layouts.

An earlier version also included frame-level dirty tracking (gating sort+render behind a Changed<> detection system). It wasn't worth the squeeze and has been removed & squashed out to focus this PR.
