### PR TITLE
chore: reuse bevy's struct and method

### DIFF
--- a/shaders/vello_rendertarget.wgsl
+++ b/shaders/vello_rendertarget.wgsl
@@ -20,20 +20,15 @@ fn vertex(in: Vertex) -> VertexOutput {
     return out;
 }
 
-fn sRGB_OETF(a: f32) -> f32 {
-    if .04045f < a {
-        return pow((a + .055f) / 1.055f, 2.4f);
-    } else {
-        return  a / 12.92f;
-    }
-}
-
 fn linear_from_srgba(srgba: vec4<f32>) -> vec4<f32> {
-    return vec4<f32>(
-        sRGB_OETF(srgba.r),
-        sRGB_OETF(srgba.g),
-        sRGB_OETF(srgba.b),
-        srgba.a);
+    return vec4(
+        select(
+            srgba.rgb / 12.92,
+            pow((srgba.rgb + .055) / 1.055, vec3(2.4)),
+            srgba.rgb > vec3(0.04045)
+        ),
+        srgba.a,
+    );
 }
 
 @fragment

--- a/shaders/vello_rendertarget.wgsl
+++ b/shaders/vello_rendertarget.wgsl
@@ -1,4 +1,5 @@
-#import bevy_render::view::View
+#import bevy_render::view::{View, frag_coord_to_uv}
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
 
 @group(0) @binding(0)
 var<uniform> view: View;
@@ -7,29 +8,15 @@ var texture: texture_2d<f32>;
 @group(2) @binding(1)
 var texture_sampler: sampler;
 
-// returns the (0-1, 0-1) position within the given viewport for the current buffer coords .
-// buffer coords can be obtained from `@builtin(position).xy`.
-// the view uniform struct contains the current camera viewport in `view.viewport`.
-// topleft = 0,0
-fn coords_to_viewport_uv(position: vec2<f32>, viewport: vec4<f32>) -> vec2<f32> {
-    return (position - viewport.xy) / viewport.zw;
-}
-
 struct Vertex {
     @location(0) position: vec3<f32>,
 };
 
-struct VertexOutput {
-    @builtin(position) clip_position: vec4<f32>,
-    #import bevy_sprite::mesh2d_vertex_output
-};
-
 @vertex
-fn vertex(vertex: Vertex) -> VertexOutput {
-    let position = vertex.position;
+fn vertex(in: Vertex) -> VertexOutput {
     var out: VertexOutput;
-    out.clip_position = vec4<f32>(position, 1.0);
-
+    // This is the `clip position`.
+    out.position = vec4<f32>(in.position, 1.0);
     return out;
 }
 
@@ -50,12 +37,9 @@ fn linear_from_srgba(srgba: vec4<f32>) -> vec4<f32> {
 }
 
 @fragment
-fn fragment(
-    @builtin(position) position: vec4<f32>,
-    #import bevy_sprite::mesh2d_vertex_output
-) -> @location(0) vec4<f32> {
-    let uvs = coords_to_viewport_uv(position.xy, view.viewport);
-    let color = textureSample(texture, texture_sampler, uvs);
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    let uv = frag_coord_to_uv(in.position.xy, view.viewport);
+    let color = textureSample(texture, texture_sampler, uv);
     let color_converted = linear_from_srgba(color);
     return color_converted;
 }


### PR DESCRIPTION
The `VertexOutput` and `coords_to_viewport_uv` are already available in bevy, so we can reuse them.

- `VertexOutput`: [`VertexOutput`](https://github.com/bevyengine/bevy/blob/582c074ede40259d16de7db15fcff12872cf38ee/crates/bevy_sprite_render/src/mesh2d/mesh2d_vertex_output.wgsl#L3-L16)
 - `coords_to_viewport_uv`: [`frag_coord_to_uv`](https://github.com/bevyengine/bevy/blob/main/crates/bevy_render/src/view/view.wgsl#L257-L261)

