### PR TITLE
switch scene authoring paths from direct Vello scenes to imaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,12 +1656,15 @@ name = "bevy_vello"
 version = "0.13.1"
 dependencies = [
  "bevy",
+ "imaging",
+ "imaging_vello",
  "parley",
+ "svg_imaging",
  "thiserror 2.0.18",
  "tracing",
  "velato",
+ "velato_imaging",
  "vello",
- "vello_svg",
  "wasm-bindgen-test",
 ]
 
@@ -1978,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "color"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
 
 [[package]]
 name = "color_quant"
@@ -3233,6 +3236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "headless"
 version = "0.13.1"
 dependencies = [
@@ -3428,6 +3440,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
+name = "imaging"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a5e8c7c22da30056963bac3deab021ce768df9e73a252d3c07f854f2664b4d"
+dependencies = [
+ "kurbo",
+ "peniko",
+]
+
+[[package]]
+name = "imaging_vello"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c6dc0ab80d17378f6cc85331f79db2da3685a510014be77589ed07a346fa09"
+dependencies = [
+ "imaging",
+ "imaging_wgpu",
+ "kurbo",
+ "peniko",
+ "vello",
+]
+
+[[package]]
+name = "imaging_wgpu"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f8d1c8e08790c1780c2c9d42992156372a8416775e08861b322dbef654eece"
+dependencies = [
+ "imaging",
+ "wgpu",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,12 +3613,13 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
  "arrayvec",
  "euclid",
+ "polycool",
  "smallvec",
 ]
 
@@ -4447,9 +4493,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
 dependencies = [
  "color",
  "kurbo",
@@ -4584,6 +4630,15 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -5374,6 +5429,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
+name = "svg_imaging"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44a74005d79358c9b53269a18d60010331fd313fe8d5f308a1b5e51df097c59"
+dependencies = [
+ "hashbrown 0.17.1",
+ "image",
+ "imaging",
+ "kurbo",
+ "peniko",
+ "usvg",
+]
+
+[[package]]
 name = "svg_screenspace"
 version = "0.13.1"
 dependencies = [
@@ -5566,7 +5635,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
 ]
 
 [[package]]
@@ -5574,6 +5643,17 @@ name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -5836,9 +5916,9 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
 dependencies = [
  "base64",
  "data-url",
@@ -5854,7 +5934,8 @@ dependencies = [
  "siphasher",
  "strict-num",
  "svgtypes",
- "tiny-skia-path",
+ "tiny-skia-path 0.12.0",
+ "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -5917,6 +5998,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "velato_imaging"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c462d986c4b8a792cd4808874240bd44c9488883ca793c52eddf821a7259a5c"
+dependencies = [
+ "imaging",
+ "kurbo",
+ "peniko",
+ "velato",
+]
+
+[[package]]
 name = "vello"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5959,18 +6052,6 @@ dependencies = [
  "naga",
  "thiserror 2.0.18",
  "vello_encoding",
-]
-
-[[package]]
-name = "vello_svg"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79dfa03829a8fb45ad458a05bd533d399d2259d042cdd78f391b290dbbdf1bd3"
-dependencies = [
- "image",
- "thiserror 2.0.18",
- "usvg",
- "vello",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,14 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy = { workspace = true }
+imaging = "0.0.1"
+imaging_vello = { version = "0.0.1", default-features = false, features = ["vello-0-7"] }
 # Ensure this version stays up to date with the README
 vello = "0.7.0"
 thiserror = "2.0.18"
-vello_svg = { version = "0.9.0", optional = true }
+svg_imaging = { version = "0.0.1", optional = true }
 velato = { version = "0.10.0", optional = true }
+velato_imaging = { version = "0.0.1", optional = true }
 tracing = "0.1.44"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -73,7 +76,7 @@ wasm-bindgen-test = "0.3.64"
 [features]
 default = []
 picking = ["bevy/bevy_picking"]
-svg = ["vello_svg"]
-lottie = ["velato"]
+svg = ["dep:svg_imaging"]
+lottie = ["dep:velato", "dep:velato_imaging"]
 text = ["parley"]
 default_font = ["bevy/default_font", "text"]

--- a/src/integrations/error.rs
+++ b/src/integrations/error.rs
@@ -8,8 +8,8 @@ pub enum VectorLoaderError {
     #[error("Could not parse utf-8: {0}")]
     FromStrUtf8(#[from] std::str::Utf8Error),
     #[cfg(feature = "svg")]
-    #[error("Could not parse svg: {0}")]
-    VelloSvg(#[from] vello_svg::Error),
+    #[error("Could not lower svg through imaging: {0}")]
+    SvgImaging(#[from] svg_imaging::Error),
     #[cfg(feature = "lottie")]
     #[error("Could not parse lottie: {0}")]
     Velato(#[from] velato::Error),

--- a/src/integrations/scene/mod.rs
+++ b/src/integrations/scene/mod.rs
@@ -6,44 +6,130 @@ pub(crate) use plugin::SceneIntegrationPlugin;
 
 use bevy::camera::visibility::{self, VisibilityClass};
 use bevy::prelude::*;
+use imaging::FillRef;
+use vello::{kurbo, peniko};
+
+const PATH_TOLERANCE: f64 = 0.1;
 
 /// A renderable scene in the world.
 ///
-/// A simple newtype component wrapper for [`vello::Scene`].
+/// This is a retained imaging scene that is lowered into the transient frame `vello::Scene`
+/// during rendering.
 #[derive(Component, Default, Clone, Deref, DerefMut)]
 #[require(Aabb, Transform, Visibility, VisibilityClass)]
 #[cfg_attr(feature = "picking", require(Pickable))]
 #[component(on_add = visibility::add_visibility_class::<VelloScene2d>)]
-pub struct VelloScene2d(Box<vello::Scene>);
+pub struct VelloScene2d(Box<imaging::record::Scene>);
 
 impl VelloScene2d {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Clear all recorded commands.
+    pub fn reset(&mut self) {
+        self.0.clear();
+    }
+
+    /// Fill a shape using Vello-like authoring parameters.
+    pub fn fill<'a>(
+        &mut self,
+        fill_rule: peniko::Fill,
+        transform: kurbo::Affine,
+        brush: impl Into<peniko::BrushRef<'a>>,
+        brush_transform: Option<kurbo::Affine>,
+        shape: &impl kurbo::Shape,
+    ) {
+        imaging::PaintSink::fill(
+            &mut *self.0,
+            FillRef::new(shape.to_path(PATH_TOLERANCE), brush)
+                .fill_rule(fill_rule)
+                .transform(transform)
+                .brush_transform(brush_transform),
+        );
+    }
+
+    /// Stroke a shape using Vello-like authoring parameters.
+    pub fn stroke<'a>(
+        &mut self,
+        stroke: &'a kurbo::Stroke,
+        transform: kurbo::Affine,
+        brush: impl Into<peniko::BrushRef<'a>>,
+        brush_transform: Option<kurbo::Affine>,
+        shape: &impl kurbo::Shape,
+    ) {
+        imaging::PaintSink::stroke(
+            &mut *self.0,
+            imaging::StrokeRef::new(shape.to_path(PATH_TOLERANCE), stroke, brush)
+                .transform(transform)
+                .brush_transform(brush_transform),
+        );
+    }
 }
 
-impl From<vello::Scene> for VelloScene2d {
-    fn from(scene: vello::Scene) -> Self {
+impl From<imaging::record::Scene> for VelloScene2d {
+    fn from(scene: imaging::record::Scene) -> Self {
         Self(Box::new(scene))
     }
 }
 
 /// A renderable scene that may be used in Bevy UI.
 ///
-/// A simple newtype component wrapper for [`vello::Scene`].
+/// This is a retained imaging scene that is lowered into the transient frame `vello::Scene`
+/// during rendering.
 #[derive(Component, Default, Clone, Deref, DerefMut)]
 #[require(Aabb, UiTransform, Visibility, VisibilityClass)]
 #[component(on_add = visibility::add_visibility_class::<UiVelloScene>)]
-pub struct UiVelloScene(Box<vello::Scene>);
+pub struct UiVelloScene(Box<imaging::record::Scene>);
 
 impl UiVelloScene {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Clear all recorded commands.
+    pub fn reset(&mut self) {
+        self.0.clear();
+    }
+
+    /// Fill a shape using Vello-like authoring parameters.
+    pub fn fill<'a>(
+        &mut self,
+        fill_rule: peniko::Fill,
+        transform: kurbo::Affine,
+        brush: impl Into<peniko::BrushRef<'a>>,
+        brush_transform: Option<kurbo::Affine>,
+        shape: &impl kurbo::Shape,
+    ) {
+        imaging::PaintSink::fill(
+            &mut *self.0,
+            FillRef::new(shape.to_path(PATH_TOLERANCE), brush)
+                .fill_rule(fill_rule)
+                .transform(transform)
+                .brush_transform(brush_transform),
+        );
+    }
+
+    /// Stroke a shape using Vello-like authoring parameters.
+    pub fn stroke<'a>(
+        &mut self,
+        stroke: &'a kurbo::Stroke,
+        transform: kurbo::Affine,
+        brush: impl Into<peniko::BrushRef<'a>>,
+        brush_transform: Option<kurbo::Affine>,
+        shape: &impl kurbo::Shape,
+    ) {
+        imaging::PaintSink::stroke(
+            &mut *self.0,
+            imaging::StrokeRef::new(shape.to_path(PATH_TOLERANCE), stroke, brush)
+                .transform(transform)
+                .brush_transform(brush_transform),
+        );
+    }
 }
 
-impl From<vello::Scene> for UiVelloScene {
-    fn from(scene: vello::Scene) -> Self {
+impl From<imaging::record::Scene> for UiVelloScene {
+    fn from(scene: imaging::record::Scene) -> Self {
         Self(Box::new(scene))
     }
 }

--- a/src/integrations/svg/asset.rs
+++ b/src/integrations/svg/asset.rs
@@ -2,11 +2,9 @@ use std::sync::Arc;
 
 use bevy::{prelude::*, reflect::TypePath};
 
-use crate::prelude::*;
-
 #[derive(Asset, TypePath, Clone)]
 pub struct VelloSvg {
-    pub scene: Arc<vello::Scene>,
+    pub scene: Arc<imaging::record::Scene>,
     pub width: f32,
     pub height: f32,
     pub alpha: f32,

--- a/src/integrations/svg/parse.rs
+++ b/src/integrations/svg/parse.rs
@@ -1,22 +1,22 @@
 use std::sync::Arc;
-use vello_svg::usvg::{self};
 
 use super::asset::VelloSvg;
 use crate::integrations::VectorLoaderError;
 
 /// Deserialize an SVG file from bytes.
 pub fn load_svg_from_bytes(bytes: &[u8]) -> Result<VelloSvg, VectorLoaderError> {
-    let svg_str = std::str::from_utf8(bytes)?;
+    let mut options = svg_imaging::ParseOptions::default();
+    options.fontdb_mut().load_system_fonts();
+    let document = svg_imaging::SvgDocument::from_data(bytes, &options)?;
+    let mut scene = imaging::record::Scene::new();
+    {
+        let mut painter = imaging::Painter::new(&mut scene);
+        document.render(&mut painter, &svg_imaging::RenderOptions::default())?;
+    }
 
-    // Parse SVG
-    let tree =
-        usvg::Tree::from_str(svg_str, &usvg::Options::default()).map_err(vello_svg::Error::Svg)?;
-
-    // Process the loaded SVG into Vello-compatible data
-    let scene = vello_svg::render_tree(&tree);
-
-    let width = tree.size().width();
-    let height = tree.size().height();
+    let size = document.size();
+    let width = size.width as f32;
+    let height = size.height as f32;
 
     let asset = VelloSvg {
         scene: Arc::new(scene),

--- a/src/integrations/text/font.rs
+++ b/src/integrations/text/font.rs
@@ -1,14 +1,14 @@
 use std::borrow::Cow;
 
 use bevy::{prelude::*, reflect::TypePath, render::render_asset::RenderAsset};
+use imaging::{GlyphRunRef, PaintSink as _};
 use parley::{
     FontSettings, FontStyle, FontVariation, Layout, PositionedLayoutItem, RangedBuilder,
     StyleProperty,
 };
 use vello::{
-    Scene,
     kurbo::Affine,
-    peniko::{Brush, Fill},
+    peniko::{Brush, Fill, Style},
 };
 
 use super::{VelloFontAxes, VelloTextAnchor, context::LOCAL_FONT_CONTEXT};
@@ -89,7 +89,7 @@ impl VelloFont {
     #[expect(clippy::too_many_arguments, reason = "Common lint in bevy")]
     pub(crate) fn render(
         &self,
-        scene: &mut Scene,
+        scene: &mut imaging::record::Scene,
         mut transform: Affine,
         value: &str,
         style: &VelloTextStyle,
@@ -183,28 +183,31 @@ impl VelloFont {
                 let glyph_xform = synthesis
                     .skew()
                     .map(|angle| Affine::skew(angle.to_radians().tan() as f64, 0.0));
-
-                scene
-                    .draw_glyphs(font)
-                    .brush(&style.brush)
-                    .hint(true)
-                    .transform(transform)
-                    .glyph_transform(glyph_xform)
-                    .font_size(font_size)
-                    .normalized_coords(run.normalized_coords())
-                    .draw(
-                        Fill::NonZero,
-                        glyph_run.glyphs().map(|glyph| {
-                            let gx = x + glyph.x;
-                            let gy = y - glyph.y;
-                            x += glyph.advance;
-                            vello::Glyph {
-                                id: glyph.id as _,
-                                x: gx,
-                                y: gy,
-                            }
-                        }),
-                    );
+                let glyph_style = Style::Fill(Fill::NonZero);
+                let draw = GlyphRunRef {
+                    font,
+                    transform,
+                    glyph_transform: glyph_xform,
+                    brush_transform: None,
+                    font_size,
+                    font_embolden: imaging::kurbo::Vec2::ZERO,
+                    hint: true,
+                    normalized_coords: run.normalized_coords(),
+                    style: &glyph_style,
+                    brush: (&style.brush).into(),
+                    composite: imaging::Composite::default(),
+                };
+                let mut glyphs = glyph_run.glyphs().map(|glyph| {
+                    let gx = x + glyph.x;
+                    let gy = y - glyph.y;
+                    x += glyph.advance;
+                    imaging::record::Glyph {
+                        id: glyph.id as _,
+                        x: gx,
+                        y: gy,
+                    }
+                });
+                scene.glyph_run(draw, &mut glyphs);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,17 @@ pub mod integrations;
 pub mod render;
 
 // Re-exports
+pub use imaging;
+pub use imaging_vello;
 #[cfg(feature = "text")]
 pub use parley;
+#[cfg(feature = "svg")]
+pub use svg_imaging;
 #[cfg(feature = "lottie")]
 pub use velato;
+#[cfg(feature = "lottie")]
+pub use velato_imaging;
 pub use vello;
-#[cfg(feature = "svg")]
-pub use vello_svg;
 
 pub mod prelude {
     // Vendor re-exports

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -37,6 +37,26 @@ use crate::{
     render::{VelloUiRenderItem, VelloView},
 };
 
+fn render_target_bounds(gpu_image: &GpuImage) -> vello::kurbo::Rect {
+    vello::kurbo::Rect::new(
+        0.0,
+        0.0,
+        gpu_image.size.width as f64,
+        gpu_image.size.height as f64,
+    )
+}
+
+fn replay_imaging_scene(
+    scene_buffer: &mut Scene,
+    scene: &imaging::record::Scene,
+    affine: vello::kurbo::Affine,
+    surface_clip: vello::kurbo::Rect,
+) {
+    let mut sink = imaging_vello::VelloSceneSink::new(scene_buffer, surface_clip);
+    imaging::record::replay_transformed(scene, &mut sink, affine);
+    sink.finish().unwrap();
+}
+
 /// Convert a Bevy UI clip rect to a Vello kurbo rect.
 ///
 /// `CalculatedClip` is already in physical pixels — Bevy resolves layout
@@ -283,6 +303,7 @@ pub fn render_frame(
 ) {
     let VelloRenderTarget(render_target_image) = *render_target;
     let gpu_image = gpu_images.get(render_target_image).unwrap();
+    let surface_clip = render_target_bounds(gpu_image);
 
     let mut scene_buffer = Scene::new();
 
@@ -293,7 +314,7 @@ pub fn render_frame(
                 affine,
                 item: ExtractedVelloScene2d { scene, .. },
             } => {
-                scene_buffer.append(scene, Some(*affine));
+                replay_imaging_scene(&mut scene_buffer, scene, *affine, surface_clip);
             }
             #[cfg(feature = "lottie")]
             VelloWorldRenderItem::Lottie {
@@ -326,13 +347,20 @@ pub fn render_frame(
                 }
                 let recolored = theme.as_ref().map(|cs| cs.recolor(&asset.composition));
                 let animation = recolored.as_ref().unwrap_or(&asset.composition);
-                velato_renderer.append(
-                    animation,
-                    *playhead as f64,
-                    *affine,
-                    1.0,
-                    &mut scene_buffer,
-                );
+                {
+                    let mut sink =
+                        imaging_vello::VelloSceneSink::new(&mut scene_buffer, surface_clip);
+                    velato_imaging::RendererExt::append_to_imaging(
+                        &mut velato_renderer.0,
+                        animation,
+                        *playhead as f64,
+                        *affine,
+                        1.0,
+                        &mut sink,
+                    )
+                    .unwrap();
+                    sink.finish().unwrap();
+                }
                 if *alpha < 1.0 {
                     scene_buffer.pop_layer();
                 }
@@ -354,7 +382,7 @@ pub fn render_frame(
                         &vello::kurbo::Rect::new(0.0, 0.0, asset.width as f64, asset.height as f64),
                     );
                 }
-                scene_buffer.append(&asset.scene, Some(*affine));
+                replay_imaging_scene(&mut scene_buffer, &asset.scene, *affine, surface_clip);
                 if *alpha < 1.0 {
                     scene_buffer.pop_layer();
                 }
@@ -368,8 +396,9 @@ pub fn render_frame(
                     },
             } => {
                 if let Some(font) = font_render_assets.get(text.style.font.id()) {
+                    let mut text_scene = imaging::record::Scene::new();
                     font.render(
-                        &mut scene_buffer,
+                        &mut text_scene,
                         *affine,
                         &text.value,
                         &text.style,
@@ -378,6 +407,12 @@ pub fn render_frame(
                         *text_anchor,
                         None,
                         None,
+                    );
+                    replay_imaging_scene(
+                        &mut scene_buffer,
+                        &text_scene,
+                        vello::kurbo::Affine::IDENTITY,
+                        surface_clip,
                     );
                 }
             }
@@ -424,7 +459,7 @@ pub fn render_frame(
                 item: ExtractedUiVelloScene { scene, .. },
                 ..
             } => {
-                scene_buffer.append(scene, Some(*affine));
+                replay_imaging_scene(&mut scene_buffer, scene, *affine, surface_clip);
             }
             #[cfg(feature = "lottie")]
             VelloUiRenderItem::Lottie {
@@ -455,13 +490,20 @@ pub fn render_frame(
                 }
                 let recolored = theme.as_ref().map(|cs| cs.recolor(&asset.composition));
                 let animation = recolored.as_ref().unwrap_or(&asset.composition);
-                velato_renderer.append(
-                    animation,
-                    *playhead as f64,
-                    *affine,
-                    1.0,
-                    &mut scene_buffer,
-                );
+                {
+                    let mut sink =
+                        imaging_vello::VelloSceneSink::new(&mut scene_buffer, surface_clip);
+                    velato_imaging::RendererExt::append_to_imaging(
+                        &mut velato_renderer.0,
+                        animation,
+                        *playhead as f64,
+                        *affine,
+                        1.0,
+                        &mut sink,
+                    )
+                    .unwrap();
+                    sink.finish().unwrap();
+                }
                 if *alpha < 1.0 {
                     scene_buffer.pop_layer();
                 }
@@ -481,7 +523,7 @@ pub fn render_frame(
                         &vello::kurbo::Rect::new(0.0, 0.0, asset.width as f64, asset.height as f64),
                     );
                 }
-                scene_buffer.append(&asset.scene, Some(*affine));
+                replay_imaging_scene(&mut scene_buffer, &asset.scene, *affine, surface_clip);
                 if *alpha < 1.0 {
                     scene_buffer.pop_layer();
                 }
@@ -501,8 +543,9 @@ pub fn render_frame(
             } => {
                 if let Some(font) = font_render_assets.get(text.style.font.id()) {
                     let logical_size = ui_node.size() / ui_render_target.scale_factor();
+                    let mut text_scene = imaging::record::Scene::new();
                     font.render(
-                        &mut scene_buffer,
+                        &mut text_scene,
                         *affine,
                         &text.value,
                         &text.style,
@@ -511,6 +554,12 @@ pub fn render_frame(
                         *text_anchor,
                         Some(logical_size),
                         *clip,
+                    );
+                    replay_imaging_scene(
+                        &mut scene_buffer,
+                        &text_scene,
+                        vello::kurbo::Affine::IDENTITY,
+                        surface_clip,
                     );
                 }
             }


### PR DESCRIPTION
This draft moves `bevy_vello` toward an imaging-first architecture while keeping Vello as the final rendering backend.

The main change is that scene-producing integrations no longer author directly into `vello::Scene`. Instead, they lower into `imaging::record::Scene`, and the renderer replays those retained imaging scenes into the transient frame `vello::Scene` via `imaging_vello::VelloSceneSink`.

This is intended as the first stage of the migration, not the final cleanup pass.

# Why

`bevy_vello` has historically exposed native `vello::Scene` as both its public scene model and its internal interchange format. That makes the crate tightly coupled to one backend and forces each integration path to speak Vello directly.

With `imaging`, `svg_imaging`, and `velato_imaging` now available, we can move scene authoring and format lowering onto a shared retained IR while still using Vello for actual rendering.

That gives us:

* one scene model for hand-authored scenes, SVG, Lottie, and text
* less backend-specific logic in integration code
* a cleaner long-term boundary: Bevy plumbing here, lowering in `imaging` adapters, rendering in backend-specific sinks.
* Vello as one backend, not the only authoring model
* future support for alternate imaging backends without redoing all format integrations
# What changed

* `VelloScene2d` and `UiVelloScene` now retain `imaging::record::Scene` instead of `vello::Scene`.
* The render pass now replays `imaging` scenes into the transient frame `vello::Scene` with `imaging_vello::VelloSceneSink`.

# What did not change

* Vello is still the final rendering backend.
* The frame renderer still builds one transient `vello::Scene` per frame and renders it as before.
* Existing scene APIs still use Vello/peniko vocabulary where that was already part of the crate surface.
* Pre-existing behavior outside the imaging migration was intentionally left alone where possible.

# Why this is still a draft

This gets the architecture moving in the right direction, but it is not yet the final polish pass.

In particular, this PR does not yet try to:

* fully clean up all public API naming around `VelloScene` types
* remove every remaining direct Vello-typed concept from the public surface
* optimize replay/caching of static imaging scenes
* do the final pass on docs, migration notes, and example cleanup

So this should be read as the structural first step, not the finished end state.

# Follow-up work

* rename/reframe scene APIs to reflect imaging-first authoring rather than Vello-first naming
* continue separating backend-specific replay from the rest of the render pipeline
* add support for additional imaging backends beyond Vello
* tighten docs and migration notes
* evaluate caching for static retained scenes
