### PR TITLE
Fix ambiguous import visiblity lint

### DIFF
--- a/src/integrations/lottie/systems.rs
+++ b/src/integrations/lottie/systems.rs
@@ -2,9 +2,9 @@ use std::time::Duration;
 
 use super::{LottiePlayer, PlayerTransition, asset::VelloLottie};
 use crate::{
-    PlaybackDirection, PlaybackLoopBehavior, PlaybackOptions, Playhead,
     integrations::lottie::{
-        LottieAssetVariant, PlaybackPlayMode, UiVelloLottie, VelloLottie2d,
+        LottieAssetVariant, PlaybackDirection, PlaybackLoopBehavior, PlaybackOptions,
+        PlaybackPlayMode, Playhead, UiVelloLottie, VelloLottie2d,
         player::events::{LottieOnAfterEvent, LottieOnCompletedEvent, LottieOnShowEvent},
     },
     prelude::VelloLottieAnchor,

--- a/src/integrations/text/systems.rs
+++ b/src/integrations/text/systems.rs
@@ -1,4 +1,4 @@
-use crate::{VelloFont, prelude::*};
+use crate::prelude::*;
 use bevy::{
     asset::AssetEvent,
     camera::primitives::Aabb,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 // #![deny(missing_docs)] -- This would be great! But we are far away.
 //! An integration to render SVG and Lottie assets in Bevy with Vello.
 
-use crate::prelude::*;
-
 mod plugin;
 pub use plugin::VelloPlugin;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,10 +1,7 @@
 use bevy::{camera::visibility::RenderLayers, prelude::*};
 use vello::AaConfig;
 
-use crate::{
-    VelloRenderSettings,
-    render::{VelloCanvasSettings, VelloRenderPlugin},
-};
+use crate::render::{VelloCanvasSettings, VelloRenderPlugin, VelloRenderSettings};
 
 #[derive(Clone)]
 pub struct VelloPlugin {

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -10,13 +10,10 @@ use bevy::{
 };
 
 use super::{VelloCanvasSettings, VelloRenderSettings, extract::VelloRenderTarget, systems};
-use crate::{
-    VelloView,
-    render::{
-        RT_SHADER_HANDLE, VelloCanvasMaterial, VelloEntityCountData, VelloFrameProfileData,
-        VelloRenderQueue, VelloRenderer, diagnostics::VelloRenderDiagnosticsPlugin,
-        extract::VelloExtractStep,
-    },
+use crate::render::{
+    RT_SHADER_HANDLE, VelloCanvasMaterial, VelloEntityCountData, VelloFrameProfileData,
+    VelloRenderQueue, VelloRenderer, VelloView, diagnostics::VelloRenderDiagnosticsPlugin,
+    extract::VelloExtractStep,
 };
 
 #[derive(Default)]


### PR DESCRIPTION
With a current Rust, you get this warning:

```
warning: ambiguous import visibility: pub or pub(crate)
  --> src/lib.rs:21:9
   |
21 | pub use vello;
   |         ^^^^^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
   = note: `vello` could refer to a crate passed with `--extern`
   = help: use `::vello` to refer to this crate unambiguously
note: `vello` could also refer to the crate imported here
  --> src/lib.rs:5:5
   |
 5 | use crate::prelude::*;
   |     ^^^^^^^^^^^^^^^^^
   = help: consider adding an explicit import of `vello` to disambiguate
   = help: or use `crate::vello` to refer to this crate unambiguously
   = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default

warning: `bevy_vello` (lib) generated 1 warning
```